### PR TITLE
#KL25-59 カメラ撮影動作クラスの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # ディレクトリ
 bin
+datafiles/snapshots

--- a/modules/CameraCapture/CameraCapture.cpp
+++ b/modules/CameraCapture/CameraCapture.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "CameraCapture.h"
+#include <filesystem>
+
 using namespace std;
 
 CameraCapture::CameraCapture()
@@ -119,6 +121,15 @@ bool CameraCapture::saveFrame(const cv::Mat& frame, string filepath, string file
     cerr << "保存するフレームがありません。" << endl;
     return false;
   }
+
+  // ディレクトリが存在しない場合は作成
+  if(!filesystem::exists(filepath)) {
+    if(!filesystem::create_directories(filepath)) {
+      std::cerr << "ディレクトリの作成に失敗しました: " << filepath << std::endl;
+      return false;
+    }
+  }
+
   string imagePath = filepath + "/" + filename + imgExtension;
   if(!cv::imwrite(imagePath, frame)) {
     cerr << "画像の保存に失敗しました: " << imagePath << endl;

--- a/modules/motions/Snapshot.cpp
+++ b/modules/motions/Snapshot.cpp
@@ -1,0 +1,23 @@
+/**
+ * @file   Snapshot.cpp
+ * @brief  写真を撮影して保存するクラス
+ * @author takuchi17
+ */
+
+#include "Snapshot.h"
+
+Snapshot::Snapshot(Robot& _robot, const std::string& _fileName)
+  : Motion(_robot), fileName(_fileName)
+{
+}
+
+void Snapshot::run()
+{
+  // 写真を撮影する
+  cv::Mat frame;
+  if(!robot.getCameraCaptureInstance().getFrame(frame)) {
+    return;
+  }
+  // 写真を保存する
+  robot.getCameraCaptureInstance().saveFrame(frame, path, fileName);
+}

--- a/modules/motions/Snapshot.h
+++ b/modules/motions/Snapshot.h
@@ -1,0 +1,31 @@
+/**
+ * @file   Snapshot.h
+ * @brief  写真を撮影して保存するクラス
+ * @author takuchi17
+ */
+
+#ifndef SNAPSHOT_H
+#define SNAPSHOT_H
+
+#include "Motion.h"
+
+class Snapshot : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   * @param _robot 外部リソースのインスタンス
+   *
+   */
+  Snapshot(Robot& _robot, const std::string& _fileName);
+
+  /**
+   * @brief カメラ撮影を行い、画像を保存する
+   */
+  void run() override;
+
+ private:
+  std::string fileName;                                     // 保存するファイル名
+  std::string path = "etrobocon2025/datafiles/snapshots/";  // 保存するパス
+};
+
+#endif

--- a/tests/SnapshotTest.cpp
+++ b/tests/SnapshotTest.cpp
@@ -1,0 +1,20 @@
+/**
+ * @file   SnapshotTest.cpp
+ * @brief  SnapshotTestクラスのテスト
+ * @author takuchi17
+ */
+
+#include <gtest/gtest.h>
+#include "Snapshot.h"
+
+namespace etrobocon2025_test {
+  // CameraCaptureクラスがインスタンス化できるか確認するテスト
+  TEST(SnapshotTest, SnapshotInit)
+  {
+    Robot robot;
+    Snapshot snapshot(robot, "test_snapshot");
+
+    // Snapshotのインスタンスが正常に作成されたか確認
+    EXPECT_NO_THROW(snapshot.run());
+  }
+}  // namespace etrobocon2025_test

--- a/tests/SnapshotTest.cpp
+++ b/tests/SnapshotTest.cpp
@@ -8,13 +8,14 @@
 #include "Snapshot.h"
 
 namespace etrobocon2025_test {
-  // CameraCaptureクラスがインスタンス化できるか確認するテスト
+
+  // Snapshotのrun()メソッドが実行できるか確認するテスト
   TEST(SnapshotTest, SnapshotInit)
   {
     Robot robot;
     Snapshot snapshot(robot, "test_snapshot");
 
-    // Snapshotのインスタンスが正常に作成されたか確認
     EXPECT_NO_THROW(snapshot.run());
   }
+
 }  // namespace etrobocon2025_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- 1枚写真を撮る動作クラス`Snapshot`を追加
- 画像保存先のディレクトリが無いときに作成するように`CameraCapture`クラスの`saveFrame`関数を変更

# 動作テスト
[Notion](https://www.notion.so/uom-katlab/209dd5b1cc18800d9f53f56f012045b5?source=copy_link#209dd5b1cc1880d5a40ee6cefb2b6b36)
