### PR TITLE
#KL25-68 カメラライントレース（カメラpid走行）動作クラスを実装する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,11 +39,11 @@ set(INCLUDE_DIRS
   ${PROJECT_MODULE_DIR}/calculators
   ${PROJECT_MODULE_DIR}/common
   ${PROJECT_MODULE_DIR}/motions
+  ${PROJECT_MODULE_DIR}/image_processors
   ${PROJECT_MODULE_DIR}/API
   ${PROJECT_TEST_DIR}
   ${PROJECT_TEST_DIR}/dummy
   ${PROJECT_TEST_DIR}/helpers
-  /usr/include/opencv4
 )
 
 # ソースファイルの登録 (適宜登録)
@@ -52,6 +52,7 @@ file(GLOB_RECURSE PROJECT_SOURCES
   "${PROJECT_MODULE_DIR}/CameraCapture/*.cpp"
   "${PROJECT_MODULE_DIR}/calculators/*.cpp"
   "${PROJECT_MODULE_DIR}/motions/*.cpp"
+  "${PROJECT_MODULE_DIR}/image_processors/*.cpp"
   "${PROJECT_TEST_DIR}/helpers/*.cpp"
 )
 

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -18,6 +18,7 @@ APPL_DIRS += \
 	$(mkfile_path)modules/calculators\
 	$(mkfile_path)modules/common\
 	$(mkfile_path)modules/motions\
+	$(mkfile_path)modules/image_processors\
 	$(mkfile_path)modules/CameraCapture\
 	$(mkfile_path)../../common/library/libcpp-spike/src
 
@@ -27,6 +28,7 @@ INCLUDES += \
 	-I$(mkfile_path)modules/calculators\
 	-I$(mkfile_path)modules/common\
 	-I$(mkfile_path)modules/motions\
+	-I$(mkfile_path)modules/image_processors\
 	-I$(mkfile_path)modules/CameraCapture \
 	-I$(mkfile_path)../../common/library/libcpp-spike/include \
 	-I/usr/include/opencv4

--- a/modules/CameraCapture/CameraCapture.h
+++ b/modules/CameraCapture/CameraCapture.h
@@ -7,6 +7,7 @@
 #ifndef CAMERA_CAPTURE_H
 #define CAMERA_CAPTURE_H
 
+#include "ICameraCapture.h"
 #include <opencv2/opencv.hpp>
 #include <iostream>
 #include <vector>
@@ -14,7 +15,7 @@
 #include <thread>
 #include <chrono>
 
-class CameraCapture {
+class CameraCapture : public ICameraCapture {
  public:
   CameraCapture();
   ~CameraCapture();
@@ -24,40 +25,40 @@ class CameraCapture {
    * @param maxTested 探索する回数の上限
    * @return 利用可能なカメラID（見つからなければ-1）
    */
-  int findAvailableCameraID(int maxTested = 10);
+  int findAvailableCameraID(int maxTested = 10) override;
 
   /**
    * @brief クラスの変数に格納されている現在のカメラIDを取得する
    * @return 現在のクラスの変数に格納されているカメラID
    */
-  int getCameraID();
+  int getCameraID() override;
 
   /**
    * @brief カメラIDをクラスの変数に格納
    * @param id クラスの変数に格納するカメラid
    * @return 成功した場合はtrue、無効な値の場合はfalse
    */
-  bool setCameraID(int id);
+  bool setCameraID(int id) override;
 
   /**
    * @brief カメラデバイスをオープンする
    * @return openに成功した場合はtrue、失敗した場合はfalse、
    */
-  bool openCamera();
+  bool openCamera() override;
 
   /**
    * @brief カメラ画像の高さと幅を設定する
    * @param width 設定する画像の幅
    * @param height 設定する画像の高さ
    */
-  void setCapProps(double width, double height);
+  void setCapProps(double width, double height) override;
 
   /**
    * @brief 1枚のカメラ画像を取得する
    * @param outFrame 取得した画像を格納するcv::Mat参照
    * @return 画像取得に成功した場合はtrue、失敗した場合はfalse
    */
-  bool getFrame(cv::Mat& outFrame);
+  bool getFrame(cv::Mat& outFrame) override;
 
   /**
    * @brief 指定した枚数だけ、指定したミリ秒間隔でカメラ画像を取得し、配列に保存する
@@ -66,7 +67,7 @@ class CameraCapture {
    * @param millisecondInterval 画像取得の間隔（ミリ秒）
    * @return 全てのフレーム取得に成功した場合はtrue、1つでも失敗した場合はfalse
    */
-  bool getFrames(std::vector<cv::Mat>& frames, int numFrames, int millisecondInterval);
+  bool getFrames(std::vector<cv::Mat>& frames, int numFrames, int millisecondInterval) override;
 
   /**
    * @brief 画像をファイルに保存する
@@ -75,7 +76,7 @@ class CameraCapture {
    * @param filename 保存するファイル名（拡張子なし）
    * @return 保存に成功した場合はtrue、失敗した場合はfalse
    */
-  bool saveFrame(const cv::Mat& frame, std::string filepath, std::string filename);
+  bool saveFrame(const cv::Mat& frame, std::string filepath, std::string filename) override;
 
  private:
   cv::VideoCapture cap;

--- a/modules/CameraCapture/ICameraCapture.h
+++ b/modules/CameraCapture/ICameraCapture.h
@@ -1,0 +1,28 @@
+/**
+ * @file   ICameraCapture.h
+ * @brief  カメラを制御するインターフェース
+ * @author HaruArima08 miyahara046
+ */
+
+#ifndef I_CAMERA_CAPTURE_H
+#define I_CAMERA_CAPTURE_H
+
+#include <opencv2/opencv.hpp>
+#include <vector>
+#include <string>
+
+class ICameraCapture {
+ public:
+  virtual ~ICameraCapture() = default;
+
+  virtual int findAvailableCameraID(int maxTested = 10) = 0;
+  virtual int getCameraID() = 0;
+  virtual bool setCameraID(int id) = 0;
+  virtual bool openCamera() = 0;
+  virtual void setCapProps(double width, double height) = 0;
+  virtual bool getFrame(cv::Mat& outFrame) = 0;
+  virtual bool getFrames(std::vector<cv::Mat>& frames, int numFrames, int millisecondInterval) = 0;
+  virtual bool saveFrame(const cv::Mat& frame, std::string filepath, std::string filename) = 0;
+};
+
+#endif

--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -82,32 +82,34 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
       // DCL: 指定距離カメラライントレース
       // [1]:double 距離[mm], [2]:double 速度[mm/s], [3]:int X座標[px], [4-6]:double PIDゲイン,
       // [7-9]int lowerHSV, [10-12]int upperHSV, [13-16]int ROI座標[px], [17-18]int 解像度[px]
+      // 補足：ROI（Region of Interest: ライントレース用の画像内注目領域（四角形））
       case COMMAND::DCL: {
         cv::Scalar lowerHSV, upperHSV;
         cv::Rect roi;
         cv::Size resolution;
-        BoundingBoxDetector* detector = nullptr;
+        std::unique_ptr<BoundingBoxDetector> detector;
 
         lowerHSV = cv::Scalar(stoi(params[7]), stoi(params[8]), stoi(params[9]));
         upperHSV = cv::Scalar(stoi(params[10]), stoi(params[11]), stoi(params[12]));
+
         // パラメータ配列のサイズによってコンストラクタを切り替え
         if(params.size() > 18) {
           // ROI + 解像度
           roi = cv::Rect(stoi(params[13]), stoi(params[14]), stoi(params[15]), stoi(params[16]));
           resolution = cv::Size(stoi(params[17]), stoi(params[18]));
-          detector = new LineBoundingBoxDetector(lowerHSV, upperHSV, roi, resolution);
+          detector = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV, roi, resolution);
         } else if(params.size() > 16) {
           // ROIのみ
           roi = cv::Rect(stoi(params[13]), stoi(params[14]), stoi(params[15]), stoi(params[16]));
-          detector = new LineBoundingBoxDetector(lowerHSV, upperHSV, roi);
+          detector = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV, roi);
         } else {
           // HSVのみ
-          detector = new LineBoundingBoxDetector(lowerHSV, upperHSV);
+          detector = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV);
         }
 
-        DistanceCameraLineTrace* dcl = new DistanceCameraLineTrace(
+        auto dcl = new DistanceCameraLineTrace(
             robot, stod(params[1]), stod(params[2]), stoi(params[3]),
-            PidGain(stod(params[4]), stod(params[5]), stod(params[6])), *detector);
+            PidGain(stod(params[4]), stod(params[5]), stod(params[6])), std::move(detector));
         motionList.push_back(dcl);
         break;
       }

--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -81,8 +81,10 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
 
       // DCL: 指定距離カメラライントレース
       // [1]:double 距離[mm], [2]:double 速度[mm/s], [3]:int X座標[px], [4-6]:double PIDゲイン,
-      // [7-9]int lowerHSV, [10-12]int upperHSV, [13-16]int ROI座標[px], [17-18]int 解像度[px]
-      // 補足：ROI（Region of Interest: ライントレース用の画像内注目領域（四角形））
+      // [7-9]int lowerHSV, [10-12]int upperHSV,
+      // [13-16]int ROI座標[px] ([13]左上隅のx座標, [14]左上隅のy座標, [15]幅, [16]高さ),
+      // [17-18]int 解像度[px] ([17]幅, [18]高さ)
+      // 補足：ROI（Region of Interest:ライントレース用の画像内注目領域（四角形））
       case COMMAND::DCL: {
         cv::Scalar lowerHSV, upperHSV;
         cv::Rect roi;

--- a/modules/MotionParser.h
+++ b/modules/MotionParser.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <memory>
 #include "StringOperator.h"
 #include "Motion.h"
 #include "AngleRotation.h"

--- a/modules/MotionParser.h
+++ b/modules/MotionParser.h
@@ -15,6 +15,8 @@
 #include "Motion.h"
 #include "AngleRotation.h"
 #include "DistanceStraight.h"
+#include "DistanceCameraLineTrace.h"
+#include "LineBoundingBoxDetector.h"
 #include "ColorStraight.h"
 #include "ColorLineTrace.h"
 #include "DistanceLineTrace.h"
@@ -28,6 +30,7 @@ enum class COMMAND {
   DS,   // 指定距離直進
   CS,   // 指定色直進
   DL,   // 指定距離ライントレース
+  DCL,  // 指定距離カメラライントレース
   CL,   // 指定色ライントレース
   CDL,  // 色距離指定ライントレース
   EC,   // エッジ切り替え
@@ -43,6 +46,7 @@ class MotionParser {
    * @param robot ロボット本体の参照
    * @param commandFilePath ファイルパス
    * @param targetBrightness 目標輝度
+   * @param cameraCapture カメラキャプチャクラスの参照
    * @return 動作インスタンスリスト
    */
 

--- a/modules/MotionParser.h
+++ b/modules/MotionParser.h
@@ -47,7 +47,6 @@ class MotionParser {
    * @param robot ロボット本体の参照
    * @param commandFilePath ファイルパス
    * @param targetBrightness 目標輝度
-   * @param cameraCapture カメラキャプチャクラスの参照
    * @return 動作インスタンスリスト
    */
 

--- a/modules/Robot.cpp
+++ b/modules/Robot.cpp
@@ -9,7 +9,7 @@
 Robot::Robot()
   : motorController(),
     defaultCameraCapture(),
-    cameraCapturePtr(&defaultCameraCapture),
+    cameraCapture(defaultCameraCapture),
     colorSensor(EPort::PORT_E),
     clock(),
     button(),
@@ -21,7 +21,8 @@ Robot::Robot()
 // DI(依存性注入)用コンストラクタ
 Robot::Robot(ICameraCapture& cam)
   : motorController(),
-    cameraCapturePtr(&cam),
+    defaultCameraCapture(),
+    cameraCapture(cam),
     colorSensor(EPort::PORT_E),
     clock(),
     button(),

--- a/modules/Robot.cpp
+++ b/modules/Robot.cpp
@@ -38,7 +38,7 @@ MotorController& Robot::getMotorControllerInstance()
 
 ICameraCapture& Robot::getCameraCaptureInstance()
 {
-  return *cameraCapturePtr;
+  return cameraCapture;
 }
 
 spikeapi::ColorSensor& Robot::getColorSensorInstance()

--- a/modules/Robot.cpp
+++ b/modules/Robot.cpp
@@ -18,7 +18,7 @@ Robot::Robot()
 {
 }
 
-// DI用コンストラクタ
+// DI(依存性注入)用コンストラクタ
 Robot::Robot(ICameraCapture& cam)
   : motorController(),
     cameraCapturePtr(&cam),

--- a/modules/Robot.cpp
+++ b/modules/Robot.cpp
@@ -8,7 +8,20 @@
 
 Robot::Robot()
   : motorController(),
-    cameraCapture(),
+    defaultCameraCapture(),
+    cameraCapturePtr(&defaultCameraCapture),
+    colorSensor(EPort::PORT_E),
+    clock(),
+    button(),
+    forceSensor(EPort::PORT_D),
+    display()
+{
+}
+
+// DI用コンストラクタ
+Robot::Robot(ICameraCapture& cam)
+  : motorController(),
+    cameraCapturePtr(&cam),
     colorSensor(EPort::PORT_E),
     clock(),
     button(),
@@ -22,9 +35,9 @@ MotorController& Robot::getMotorControllerInstance()
   return motorController;
 }
 
-CameraCapture& Robot::getCameraCaptureInstance()
+ICameraCapture& Robot::getCameraCaptureInstance()
 {
-  return cameraCapture;
+  return *cameraCapturePtr;
 }
 
 spikeapi::ColorSensor& Robot::getColorSensorInstance()

--- a/modules/Robot.h
+++ b/modules/Robot.h
@@ -35,7 +35,7 @@ class Robot {
 
   /**
    * @brief ICameraCaptureのインスタンスの参照を返す
-   * @return メンバ変数cameraCapturePtr(ICameraCaptureの実装インスタンス)への参照
+   * @return メンバ変数cameraCapture(ICameraCaptureの実装インスタンス)への参照
    */
   ICameraCapture& getCameraCaptureInstance();
 

--- a/modules/Robot.h
+++ b/modules/Robot.h
@@ -24,7 +24,7 @@ class Robot {
    */
   Robot();
 
-  // DI 用（カメラを差し替えたいテストで使用）
+  // DI用（カメラを差し替えたいテストで使用）
   Robot(ICameraCapture& cam);
 
   /**
@@ -35,7 +35,7 @@ class Robot {
 
   /**
    * @brief ICameraCaptureのインスタンスの参照を返す
-   * @return メンバ変数cameraCapture(CameraCaptureのインスタンス)の参照
+   * @return メンバ変数cameraCapturePtr(ICameraCaptureの実装インスタンス)への参照
    */
   ICameraCapture& getCameraCaptureInstance();
 
@@ -84,7 +84,7 @@ class Robot {
  private:
   MotorController motorController;     // MotorControllerインスタンス
   ICameraCapture* cameraCapturePtr;    // 実際に使うカメラ（抽象ポインタ）
-  CameraCapture defaultCameraCapture;  // デフォルトでもっておく実体
+  CameraCapture defaultCameraCapture;  // 実機用のCameraCaptureインスタンス
   spikeapi::ColorSensor colorSensor;   // ColorSensorインスタンス
   spikeapi::Clock clock;               // Clockインスタンス
   spikeapi::Button button;             // Buttonインスタンス

--- a/modules/Robot.h
+++ b/modules/Robot.h
@@ -24,6 +24,9 @@ class Robot {
    */
   Robot();
 
+  // DI 用（カメラを差し替えたいテストで使用）
+  Robot(ICameraCapture& cam);
+
   /**
    * @brief MotorControllerのインスタンスの参照を返す
    * @return メンバ変数motorController(MotorControllerのインスタンス)の参照
@@ -31,10 +34,10 @@ class Robot {
   MotorController& getMotorControllerInstance();
 
   /**
-   * @brief CameraCaptureのインスタンスの参照を返す
+   * @brief ICameraCaptureのインスタンスの参照を返す
    * @return メンバ変数cameraCapture(CameraCaptureのインスタンス)の参照
    */
-  CameraCapture& getCameraCaptureInstance();
+  ICameraCapture& getCameraCaptureInstance();
 
   /**
    * @brief ColorSensorのインスタンスの参照を返す
@@ -79,13 +82,14 @@ class Robot {
   bool getIsLeftEdge() const;
 
  private:
-  MotorController motorController;    // MotorControllerインスタンス
-  CameraCapture cameraCapture;        // CameraCaptureインスタンス
-  spikeapi::ColorSensor colorSensor;  // ColorSensorインスタンス
-  spikeapi::Clock clock;              // Clockインスタンス
-  spikeapi::Button button;            // Buttonインスタンス
-  spikeapi::ForceSensor forceSensor;  // ForceSensorインスタンス
-  spikeapi::Display display;          // Displayインスタンス
+  MotorController motorController;     // MotorControllerインスタンス
+  ICameraCapture* cameraCapturePtr;    // 実際に使うカメラ（抽象ポインタ）
+  CameraCapture defaultCameraCapture;  // デフォルトでもっておく実体
+  spikeapi::ColorSensor colorSensor;   // ColorSensorインスタンス
+  spikeapi::Clock clock;               // Clockインスタンス
+  spikeapi::Button button;             // Buttonインスタンス
+  spikeapi::ForceSensor forceSensor;   // ForceSensorインスタンス
+  spikeapi::Display display;           // Displayインスタンス
   // formatチェックをパスするためのコメント
   bool isLeftEdge = true;  // 左エッジを走行するかの真偽値
                            // （true: 左エッジ、false: 右エッジ）、初期値は左エッジ

--- a/modules/Robot.h
+++ b/modules/Robot.h
@@ -83,8 +83,8 @@ class Robot {
 
  private:
   MotorController motorController;     // MotorControllerインスタンス
-  ICameraCapture* cameraCapturePtr;    // 実際に使うカメラ（抽象ポインタ）
   CameraCapture defaultCameraCapture;  // 実機用のCameraCaptureインスタンス
+  ICameraCapture& cameraCapture;       // 実際に使うカメラ（参照）
   spikeapi::ColorSensor colorSensor;   // ColorSensorインスタンス
   spikeapi::Clock clock;               // Clockインスタンス
   spikeapi::Button button;             // Buttonインスタンス

--- a/modules/calculators/SpeedCalculator.cpp
+++ b/modules/calculators/SpeedCalculator.cpp
@@ -8,8 +8,8 @@
 SpeedCalculator::SpeedCalculator(Robot& _robot, double _targetSpeed)
   : robot(_robot),
     targetSpeed(_targetSpeed),
-    rightPid(K_P, K_I, K_D, _targetSpeed),
-    leftPid(K_P, K_I, K_D, _targetSpeed)
+    rightPid(R_K_P, R_K_I, R_K_D, _targetSpeed),
+    leftPid(L_K_P, L_K_I, L_K_D, _targetSpeed)
 {
   double currentTime = robot.getClockInstance().now() / 1000000.0;
   prevRightTime = currentTime;

--- a/modules/calculators/SpeedCalculator.cpp
+++ b/modules/calculators/SpeedCalculator.cpp
@@ -8,8 +8,8 @@
 SpeedCalculator::SpeedCalculator(Robot& _robot, double _targetSpeed)
   : robot(_robot),
     targetSpeed(_targetSpeed),
-    rightPid(R_K_P, R_K_I, R_K_D, _targetSpeed),
-    leftPid(L_K_P, L_K_I, L_K_D, _targetSpeed)
+    rightPid(RIGHT_K_P, RIGHT_K_I, RIGHT_K_D, _targetSpeed),
+    leftPid(LEFT_K_P, LEFT_K_I, LEFT_K_D, _targetSpeed)
 {
   double currentTime = robot.getClockInstance().now() / 1000000.0;
   prevRightTime = currentTime;

--- a/modules/calculators/SpeedCalculator.h
+++ b/modules/calculators/SpeedCalculator.h
@@ -42,11 +42,11 @@ class SpeedCalculator {
   double prevLeftTime;
   Robot& robot;
   // PIDゲイン
-  static constexpr double R_K_P = 0.00535;
-  static constexpr double R_K_I = 0.00115;
-  static constexpr double R_K_D = 0.000;
-  static constexpr double L_K_P = 0.00578;
-  static constexpr double L_K_I = 0.0008535;
-  static constexpr double L_K_D = 0.000;
+  static constexpr double RIGHT_K_P = 0.00535;
+  static constexpr double RIGHT_K_I = 0.00115;
+  static constexpr double RIGHT_K_D = 0.000;
+  static constexpr double LEFT_K_P = 0.00578;
+  static constexpr double LEFT_K_I = 0.0008535;
+  static constexpr double LEFT_K_D = 0.000;
 };
 #endif

--- a/modules/calculators/SpeedCalculator.h
+++ b/modules/calculators/SpeedCalculator.h
@@ -42,8 +42,11 @@ class SpeedCalculator {
   double prevLeftTime;
   Robot& robot;
   // PIDゲイン
-  static constexpr double K_P = 0.005;
-  static constexpr double K_I = 0.0002;
-  static constexpr double K_D = 0.000;
+  static constexpr double R_K_P = 0.00535;
+  static constexpr double R_K_I = 0.00115;
+  static constexpr double R_K_D = 0.000;
+  static constexpr double L_K_P = 0.00578;
+  static constexpr double L_K_I = 0.0008535;
+  static constexpr double L_K_D = 0.000;
 };
 #endif

--- a/modules/common/SystemInfo.h
+++ b/modules/common/SystemInfo.h
@@ -17,4 +17,8 @@ static constexpr double WHEEL_RADIUS = 28.0;  // 車輪の半径[mm]
 
 static const int RESOLUTION_WIDTH = 800;   // 解像度の幅（規定値）[px]
 static const int RESOLUTION_HEIGHT = 600;  // 解像度の高さ（規定値）[px]
+static constexpr int MIN_WIDTH = 320;      // 解像度の幅（最小値）[px]
+static constexpr int MIN_HEIGHT = 240;     // 解像度の高さ（最小値）[px]
+static constexpr int MAX_WIDTH = 1920;     // 解像度の幅（最大値）[px]
+static constexpr int MAX_HEIGHT = 1080;    // 解像度の高さ（最大値）[px]
 #endif

--- a/modules/common/SystemInfo.h
+++ b/modules/common/SystemInfo.h
@@ -15,10 +15,10 @@ static constexpr double TREAD = 112.0;  // 走行体のトレッド幅（両輪�
 
 static constexpr double WHEEL_RADIUS = 28.0;  // 車輪の半径[mm]
 
-static const int RESOLUTION_WIDTH = 800;   // 解像度の幅（規定値）[px]
-static const int RESOLUTION_HEIGHT = 600;  // 解像度の高さ（規定値）[px]
-static constexpr int MIN_WIDTH = 320;      // 解像度の幅（最小値）[px]
-static constexpr int MIN_HEIGHT = 240;     // 解像度の高さ（最小値）[px]
-static constexpr int MAX_WIDTH = 1920;     // 解像度の幅（最大値）[px]
-static constexpr int MAX_HEIGHT = 1080;    // 解像度の高さ（最大値）[px]
+static constexpr int RESOLUTION_WIDTH = 800;   // 解像度の幅（規定値）[px]
+static constexpr int RESOLUTION_HEIGHT = 600;  // 解像度の高さ（規定値）[px]
+static constexpr int MIN_WIDTH = 320;          // 解像度の幅（最小値）[px]
+static constexpr int MIN_HEIGHT = 240;         // 解像度の高さ（最小値）[px]
+static constexpr int MAX_WIDTH = 1920;         // 解像度の幅（最大値）[px]
+static constexpr int MAX_HEIGHT = 1080;        // 解像度の高さ（最大値）[px]
 #endif

--- a/modules/common/SystemInfo.h
+++ b/modules/common/SystemInfo.h
@@ -15,4 +15,6 @@ static constexpr double TREAD = 112.0;  // 走行体のトレッド幅（両輪�
 
 static constexpr double WHEEL_RADIUS = 28.0;  // 車輪の半径[mm]
 
+static const int RESOLUTION_WIDTH = 800;   // 解像度の幅（規定値）[px]
+static const int RESOLUTION_HEIGHT = 600;  // 解像度の高さ（規定値）[px]
 #endif

--- a/modules/image_processors/BoundingBoxDetector.h
+++ b/modules/image_processors/BoundingBoxDetector.h
@@ -1,6 +1,6 @@
 /**
  * @file   BoundingBoxDetector.h
- * @brief  画像処理の親クラス
+ * @brief  バウンディングボックス検出処理の親クラス
  * @author takuchi17 miyahara046 HaruArima08
  */
 

--- a/modules/image_processors/BoundingBoxDetector.h
+++ b/modules/image_processors/BoundingBoxDetector.h
@@ -1,0 +1,37 @@
+/**
+ * @file   BoundingBoxDetector.h
+ * @brief  画像処理の親クラス
+ * @author takuchi17 miyahara046 HaruArima08
+ */
+
+#ifndef BOUNDING_BOX_DETECTOR_H
+#define BOUNDING_BOX_DETECTOR_H
+
+#include <string>
+#include <opencv2/opencv.hpp>
+
+struct BoundingBoxDetectionResult {
+  bool wasDetected = false;  // 検出できたかどうか
+  cv::Point topLeft;         // 検出した領域の左上の座標
+  cv::Point topRight;        // 検出した領域の右上の座標
+  cv::Point bottomLeft;      // 検出した領域の左下の座標
+  cv::Point bottomRight;     // 検出した領域の右下の座標
+};
+
+class BoundingBoxDetector {
+ public:
+  /**
+   * 仮想デストラクタ
+   * @brief 派生クラスのデストラクタが正しく呼ばれるようにするために必要
+   */
+  virtual ~BoundingBoxDetector() = default;
+
+  /**
+   * @brief 物体検出を実行する純粋仮想関数
+   * @param frame 処理対象の画像フレーム
+   * @param result 結果を格納するBoundingBoxDetectionResult構造体の参照
+   */
+  virtual void detect(const cv::Mat& frame, BoundingBoxDetectionResult& result) = 0;
+};
+
+#endif

--- a/modules/image_processors/LineBoundingBoxDetector.cpp
+++ b/modules/image_processors/LineBoundingBoxDetector.cpp
@@ -105,7 +105,7 @@ void LineBoundingBoxDetector::detect(const cv::Mat& frame, BoundingBoxDetectionR
 
   // 最大輪郭の特定
   double maxArea = 0;
-  std::vector<cv::Point> largestContour = null;
+  std::vector<cv::Point> largestContour;
 
   // 輪郭をイテレート
   for(const auto& contour : contours) {

--- a/modules/image_processors/LineBoundingBoxDetector.cpp
+++ b/modules/image_processors/LineBoundingBoxDetector.cpp
@@ -1,0 +1,145 @@
+/**
+ * @file   LineBoundingBoxDetector.h
+ * @brief  ライントレース用の画像処理クラス
+ * @author takuchi17 miyahara046 HaruArima08
+ */
+#include "LineBoundingBoxDetector.h"
+
+// デフォルトコンストラクタ
+LineBoundingBoxDetector::LineBoundingBoxDetector(const cv::Scalar& _lowerHSV,
+                                                 const cv::Scalar& _upperHSV)
+  : lowerHSV(_lowerHSV), upperHSV(_upperHSV)
+{
+  roi = cv::Rect(50, 240, 540, 240);
+  resolution = cv::Size(640, 480);
+  validateParameters();
+}
+
+// ROIを指定するオーバーロードコンストラクタ
+LineBoundingBoxDetector::LineBoundingBoxDetector(const cv::Scalar& lowerHSV,
+                                                 const cv::Scalar& upperHSV, const cv::Rect& roi)
+  : lowerHSV(lowerHSV), upperHSV(upperHSV), roi(roi)
+{
+  resolution = cv::Size(640, 480);
+  validateParameters();
+}
+
+// ROIと解像度を指定するオーバーロードコンストラクタ
+LineBoundingBoxDetector::LineBoundingBoxDetector(const cv::Scalar& _lowerHSV,
+                                                 const cv::Scalar& _upperHSV, const cv::Rect& _roi,
+                                                 const cv::Size& _resolution)
+  : lowerHSV(_lowerHSV), upperHSV(_upperHSV), roi(_roi), resolution(_resolution)
+{
+  validateParameters();
+}
+
+void LineBoundingBoxDetector::validateParameters()
+{
+  // 解像度の検証：設定された解像度が定義した最小・最大値内にあるかの確認
+  if(resolution.width < ResolutionRange::MIN_WIDTH) {
+    resolution.width = ResolutionRange::MIN_WIDTH;
+  } else if(resolution.width > ResolutionRange::MAX_WIDTH) {
+    resolution.width = ResolutionRange::MAX_WIDTH;
+  }
+  if(resolution.height < ResolutionRange::MIN_HEIGHT) {
+    resolution.height = ResolutionRange::MIN_HEIGHT;
+  } else if(resolution.height > ResolutionRange::MAX_HEIGHT) {
+    resolution.height = ResolutionRange::MAX_HEIGHT;
+  }
+
+  // ROI検証：ROIの位置とサイズが解像度の枠内に収まるかの確認
+  // ROI左上座標が負の場合は0にクリップ
+  if(roi.x < 0) roi.x = 0;
+  if(roi.y < 0) roi.y = 0;
+  // ROIが解像度を超えている場合は解像度に合わせる
+  if(roi.x + roi.width > resolution.width) roi.width = resolution.width - roi.x;
+  if(roi.y + roi.height > resolution.height) roi.height = resolution.height - roi.y;
+}
+
+void LineBoundingBoxDetector::detect(const cv::Mat& frame, BoundingBoxDetectionResult& result)
+{
+  result.wasDetected = false;  // 初期状態は検出失敗
+
+  // ROIが空でないか、または画像範囲外でないかのチェック
+  if(frame.empty()) {
+    std::cerr << "Error: Input frame is empty." << std::endl;
+    return;
+  }
+
+  // 入力画像が指定の解像度と異なる場合、リサイズ処理
+  cv::Mat frameProcessed;
+  if(frame.size() != resolution) {
+    cv::resize(frame, frameProcessed, resolution);
+  } else {
+    frameProcessed = frame;
+  }
+
+  // ROIが画像サイズを超えないようにクリップする処理
+  cv::Rect roiRect = roi;
+  roiRect = roiRect & cv::Rect(0, 0, frameProcessed.cols, frameProcessed.rows);
+  // クリップした結果ROIが空になった場合
+  if(roiRect.empty()) {
+    std::cerr << "Error: ROI is empty after clipping." << std::endl;
+    return;
+  }
+
+  // ROIを切り出す
+  cv::Mat roiFrame = frameProcessed(roiRect);
+
+  // フレームをHSV色空間に変換
+  cv::Mat hsvFrame;
+  cv::cvtColor(roiFrame, hsvFrame, cv::COLOR_BGR2HSV);
+
+  // HSV範囲でマスクを設定
+  cv::Mat mask;
+  cv::inRange(hsvFrame, lowerHSV, upperHSV, mask);
+
+  // マスクを綺麗にするモルフォロジー処理のためのカーネルを作成
+  // サイズは調整が必要。
+  cv::Mat kernel = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
+
+  // オープニング（ノイズ除去）
+  cv::morphologyEx(mask, mask, cv::MORPH_OPEN, kernel);
+
+  // クロージング（ラインの結合）
+  cv::morphologyEx(mask, mask, cv::MORPH_CLOSE, kernel);
+
+  // マスクの輪郭を検出
+  std::vector<std::vector<cv::Point>> contours;
+  cv::findContours(mask.clone(), contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_SIMPLE);
+
+  // 最大輪郭の特定
+  double maxArea = 0;
+  std::vector<cv::Point> largestContour;
+  bool lineFound = false;  // ラインが見つかったかどうかのフラグ
+
+  // 輪郭をイテレート
+  for(const auto& contour : contours) {
+    double area = cv::contourArea(contour);
+    // ある程度の面積がないとノイズとみなす（この閾値は調整）
+    if(area > MIN_LINE_CONTOUR_AREA) {
+      if(area > maxArea) {
+        maxArea = area;
+        largestContour = contour;
+        lineFound = true;  // 有効なライン候補が見つかった
+      }
+    }
+  }
+
+  // ラインが見つかった場合
+  if(lineFound) {
+    result.wasDetected = true;
+
+    // 最大輪郭の外接矩形を計算
+    cv::Rect boundingBox = cv::boundingRect(largestContour);
+
+    // 矩形の4つの角の座標を設定
+    result.topLeft = cv::Point(boundingBox.x + roiRect.x, boundingBox.y + roiRect.y);
+    result.topRight
+        = cv::Point(boundingBox.x + boundingBox.width + roiRect.x, boundingBox.y + roiRect.y);
+    result.bottomLeft
+        = cv::Point(boundingBox.x + roiRect.x, boundingBox.y + boundingBox.height + roiRect.y);
+    result.bottomRight = cv::Point(boundingBox.x + boundingBox.width + roiRect.x,
+                                   boundingBox.y + boundingBox.height + roiRect.y);
+  }
+}

--- a/modules/image_processors/LineBoundingBoxDetector.cpp
+++ b/modules/image_processors/LineBoundingBoxDetector.cpp
@@ -61,7 +61,7 @@ void LineBoundingBoxDetector::detect(const cv::Mat& frame, BoundingBoxDetectionR
   }
 
   // 入力画像が指定の解像度と異なる場合、リサイズ処理
-  cv::Mat frameProcessed = frame;
+  cv::Mat frameProcessed;
   if(frame.size() != resolution) {
     cv::resize(frame, frameProcessed, resolution);
   } else {

--- a/modules/image_processors/LineBoundingBoxDetector.cpp
+++ b/modules/image_processors/LineBoundingBoxDetector.cpp
@@ -5,7 +5,7 @@
  */
 #include "LineBoundingBoxDetector.h"
 
-// ROIと解像度を指定するメインコンストラクタ
+// ROIと解像度を指定するオーバーロードコンストラクタ
 LineBoundingBoxDetector::LineBoundingBoxDetector(const cv::Scalar& _lowerHSV,
                                                  const cv::Scalar& _upperHSV, const cv::Rect& _roi,
                                                  const cv::Size& _resolution)
@@ -14,14 +14,14 @@ LineBoundingBoxDetector::LineBoundingBoxDetector(const cv::Scalar& _lowerHSV,
   validateParameters();
 }
 
-// ROIを指定するコンストラクタ
+// ROIを指定するオーバーロードコンストラクタ
 LineBoundingBoxDetector::LineBoundingBoxDetector(const cv::Scalar& _lowerHSV,
                                                  const cv::Scalar& _upperHSV, const cv::Rect& _roi)
   : LineBoundingBoxDetector(_lowerHSV, _upperHSV, _roi, cv::Size(640, 480))
 {
 }
 
-// 最小限のコンストラクタ
+// デフォルトのROIおよび解像度を使用するコンストラクタ
 LineBoundingBoxDetector::LineBoundingBoxDetector(const cv::Scalar& _lowerHSV,
                                                  const cv::Scalar& _upperHSV)
   : LineBoundingBoxDetector(_lowerHSV, _upperHSV, cv::Rect(50, 240, 540, 240), cv::Size(640, 480))

--- a/modules/image_processors/LineBoundingBoxDetector.cpp
+++ b/modules/image_processors/LineBoundingBoxDetector.cpp
@@ -105,7 +105,7 @@ void LineBoundingBoxDetector::detect(const cv::Mat& frame, BoundingBoxDetectionR
 
   // 最大輪郭の特定
   double maxArea = 0;
-  std::vector<cv::Point> largestContour;
+  std::vector<cv::Point> largestContour = null;
 
   // 輪郭をイテレート
   for(const auto& contour : contours) {

--- a/modules/image_processors/LineBoundingBoxDetector.cpp
+++ b/modules/image_processors/LineBoundingBoxDetector.cpp
@@ -60,7 +60,6 @@ void LineBoundingBoxDetector::detect(const cv::Mat& frame, BoundingBoxDetectionR
 {
   result.wasDetected = false;  // 初期状態は検出失敗
 
-  // ROIが空でないか、または画像範囲外でないかのチェック
   if(frame.empty()) {
     std::cerr << "Error: Input frame is empty." << std::endl;
     return;
@@ -70,8 +69,6 @@ void LineBoundingBoxDetector::detect(const cv::Mat& frame, BoundingBoxDetectionR
   cv::Mat frameProcessed;
   if(frame.size() != resolution) {
     cv::resize(frame, frameProcessed, resolution);
-  } else {
-    frameProcessed = frame;
   }
 
   // ROIが画像サイズを超えないようにクリップする処理
@@ -95,7 +92,8 @@ void LineBoundingBoxDetector::detect(const cv::Mat& frame, BoundingBoxDetectionR
   cv::inRange(hsvFrame, lowerHSV, upperHSV, mask);
 
   // マスクを綺麗にするモルフォロジー処理のためのカーネルを作成
-  // サイズは調整が必要。
+  // カーネルサイズは小さすぎるとノイズが除去されず、大きすぎるとラインの細部が失われるため
+  // ノイズの大きさやラインの太さに応じて調整が必要。
   cv::Mat kernel = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
 
   // オープニング（ノイズ除去）
@@ -111,35 +109,33 @@ void LineBoundingBoxDetector::detect(const cv::Mat& frame, BoundingBoxDetectionR
   // 最大輪郭の特定
   double maxArea = 0;
   std::vector<cv::Point> largestContour;
-  bool lineFound = false;  // ラインが見つかったかどうかのフラグ
 
   // 輪郭をイテレート
   for(const auto& contour : contours) {
     double area = cv::contourArea(contour);
-    // ある程度の面積がないとノイズとみなす（この閾値は調整）
-    if(area > MIN_LINE_CONTOUR_AREA) {
-      if(area > maxArea) {
-        maxArea = area;
-        largestContour = contour;
-        lineFound = true;  // 有効なライン候補が見つかった
-      }
+    // ある程度の面積がないとノイズとみなす
+    if(area > MIN_LINE_CONTOUR_AREA && area > maxArea) {
+      maxArea = area;
+      largestContour = contour;
     }
   }
 
-  // ラインが見つかった場合
-  if(lineFound) {
-    result.wasDetected = true;
-
-    // 最大輪郭の外接矩形を計算
-    cv::Rect boundingBox = cv::boundingRect(largestContour);
-
-    // 矩形の4つの角の座標を設定
-    result.topLeft = cv::Point(boundingBox.x + roiRect.x, boundingBox.y + roiRect.y);
-    result.topRight
-        = cv::Point(boundingBox.x + boundingBox.width + roiRect.x, boundingBox.y + roiRect.y);
-    result.bottomLeft
-        = cv::Point(boundingBox.x + roiRect.x, boundingBox.y + boundingBox.height + roiRect.y);
-    result.bottomRight = cv::Point(boundingBox.x + boundingBox.width + roiRect.x,
-                                   boundingBox.y + boundingBox.height + roiRect.y);
+  // ラインが見つからなかった場合、処理を終了
+  if(largestContour.empty()) {
+    return;
   }
+
+  result.wasDetected = true;
+
+  // 最大輪郭の外接矩形を計算
+  cv::Rect boundingBox = cv::boundingRect(largestContour);
+
+  // 矩形の4つの角の座標を設定
+  result.topLeft = cv::Point(boundingBox.x + roiRect.x, boundingBox.y + roiRect.y);
+  result.topRight
+      = cv::Point(boundingBox.x + boundingBox.width + roiRect.x, boundingBox.y + roiRect.y);
+  result.bottomLeft
+      = cv::Point(boundingBox.x + roiRect.x, boundingBox.y + boundingBox.height + roiRect.y);
+  result.bottomRight = cv::Point(boundingBox.x + boundingBox.width + roiRect.x,
+                                 boundingBox.y + boundingBox.height + roiRect.y);
 }

--- a/modules/image_processors/LineBoundingBoxDetector.h
+++ b/modules/image_processors/LineBoundingBoxDetector.h
@@ -46,7 +46,7 @@ class LineBoundingBoxDetector : public BoundingBoxDetector {
   void detect(const cv::Mat& frame, BoundingBoxDetectionResult& result) override;
 
  private:
-  // ラインの輪郭とみなす最小面積（この閾値は調整）
+  // 対象の輪郭とみなす最小面積（この閾値は調整）
   static constexpr double MIN_LINE_CONTOUR_AREA = 50.0;
   cv::Scalar lowerHSV;  // ライントレース対象の色の下限HSV値
   cv::Scalar upperHSV;  // ライントレース対象の色の上限HSV値

--- a/modules/image_processors/LineBoundingBoxDetector.h
+++ b/modules/image_processors/LineBoundingBoxDetector.h
@@ -8,14 +8,7 @@
 #define LINE_BOUNDING_BOX_DETECTOR_H
 
 #include "BoundingBoxDetector.h"
-
-// 解像度の最小・最大値
-struct ResolutionRange {
-  static constexpr int MIN_WIDTH = 320;
-  static constexpr int MIN_HEIGHT = 240;
-  static constexpr int MAX_WIDTH = 1920;
-  static constexpr int MAX_HEIGHT = 1080;
-};
+#include "SystemInfo.h"
 
 class LineBoundingBoxDetector : public BoundingBoxDetector {
  public:
@@ -32,8 +25,8 @@ class LineBoundingBoxDetector : public BoundingBoxDetector {
    * @param upperHSV ライントレース対象の色の上限HSV値
    * @param roi 注目領域
    */
-  LineBoundingBoxDetector(const cv::Scalar& lowerHSV, const cv::Scalar& upperHSV,
-                          const cv::Rect& roi);
+  LineBoundingBoxDetector(const cv::Scalar& _lowerHSV, const cv::Scalar& _upperHSV,
+                          const cv::Rect& _roi);
 
   /**
    * @brief ROIと解像度を指定するオーバーロードコンストラクタ
@@ -42,8 +35,8 @@ class LineBoundingBoxDetector : public BoundingBoxDetector {
    * @param roi 注目領域
    * @param resolution 画像処理に用いる解像度
    */
-  LineBoundingBoxDetector(const cv::Scalar& lowerHSV, const cv::Scalar& upperHSV,
-                          const cv::Rect& roi, const cv::Size& resolution);
+  LineBoundingBoxDetector(const cv::Scalar& _lowerHSV, const cv::Scalar& _upperHSV,
+                          const cv::Rect& _roi, const cv::Size& _resolution);
 
   /**
    * @brief 画像処理を実行する関数

--- a/modules/image_processors/LineBoundingBoxDetector.h
+++ b/modules/image_processors/LineBoundingBoxDetector.h
@@ -48,12 +48,12 @@ class LineBoundingBoxDetector : public BoundingBoxDetector {
   /**
    * @brief 画像処理を実行する関数
    * @param frame 処理対象の画像フレーム
-   * @param rusult 結果を格納するBoundingBoxDetectionResult構造体の参照
+   * @param result 結果を格納するBoundingBoxDetectionResult構造体の参照
    */
   void detect(const cv::Mat& frame, BoundingBoxDetectionResult& result) override;
 
  private:
-  // ラインの輪郭とみなす最小面積
+  // ラインの輪郭とみなす最小面積（この閾値は調整）
   static constexpr double MIN_LINE_CONTOUR_AREA = 50.0;
   cv::Scalar lowerHSV;  // ライントレース対象の色の下限HSV値
   cv::Scalar upperHSV;  // ライントレース対象の色の上限HSV値
@@ -61,7 +61,7 @@ class LineBoundingBoxDetector : public BoundingBoxDetector {
   cv::Size resolution;  // 解像度
 
   /**
-   * @brief ROIと解像度の検証を行う関数
+   * @brief 入力で受け取ったROIと解像度の検証を行う関数
    */
   void validateParameters();
 };

--- a/modules/image_processors/LineBoundingBoxDetector.h
+++ b/modules/image_processors/LineBoundingBoxDetector.h
@@ -1,0 +1,69 @@
+/**
+ * @file   LineBoundingBoxDetector.h
+ * @brief  ライントレース用の画像処理クラス
+ * @author takuchi17 miyahara046 HaruArima08
+ */
+
+#ifndef LINE_BOUNDING_BOX_DETECTOR_H
+#define LINE_BOUNDING_BOX_DETECTOR_H
+
+#include "BoundingBoxDetector.h"
+
+// 解像度の最小・最大値
+struct ResolutionRange {
+  static constexpr int MIN_WIDTH = 320;
+  static constexpr int MIN_HEIGHT = 240;
+  static constexpr int MAX_WIDTH = 1920;
+  static constexpr int MAX_HEIGHT = 1080;
+};
+
+class LineBoundingBoxDetector : public BoundingBoxDetector {
+ public:
+  /**
+   * @brief デフォルトのROIおよび解像度を使用するコンストラクタ
+   * @param lowerHSV ライントレース対象の色の下限HSV値
+   * @param upperHSV ライントレース対象の色の上限HSV値
+   */
+  LineBoundingBoxDetector(const cv::Scalar& _lowerHSV, const cv::Scalar& _upperHSV);
+
+  /**
+   * @brief ROIを指定するオーバーロードコンストラクタ
+   * @param lowerHSV ライントレース対象の色の下限HSV値
+   * @param upperHSV ライントレース対象の色の上限HSV値
+   * @param roi 注目領域
+   */
+  LineBoundingBoxDetector(const cv::Scalar& lowerHSV, const cv::Scalar& upperHSV,
+                          const cv::Rect& roi);
+
+  /**
+   * @brief ROIと解像度を指定するオーバーロードコンストラクタ
+   * @param lowerHSV ライントレース対象の色の下限HSV値
+   * @param upperHSV ライントレース対象の色の上限HSV値
+   * @param roi 注目領域
+   * @param resolution 画像処理に用いる解像度
+   */
+  LineBoundingBoxDetector(const cv::Scalar& lowerHSV, const cv::Scalar& upperHSV,
+                          const cv::Rect& roi, const cv::Size& resolution);
+
+  /**
+   * @brief 画像処理を実行する関数
+   * @param frame 処理対象の画像フレーム
+   * @param rusult 結果を格納するBoundingBoxDetectionResult構造体の参照
+   */
+  void detect(const cv::Mat& frame, BoundingBoxDetectionResult& result) override;
+
+ private:
+  // ラインの輪郭とみなす最小面積
+  static constexpr double MIN_LINE_CONTOUR_AREA = 50.0;
+  cv::Scalar lowerHSV;  // ライントレース対象の色の下限HSV値
+  cv::Scalar upperHSV;  // ライントレース対象の色の上限HSV値
+  cv::Rect roi;         // 注目領域
+  cv::Size resolution;  // 解像度
+
+  /**
+   * @brief ROIと解像度の検証を行う関数
+   */
+  void validateParameters();
+};
+
+#endif

--- a/modules/motions/CameraPidTracking.cpp
+++ b/modules/motions/CameraPidTracking.cpp
@@ -46,11 +46,16 @@ void CameraPidTracking::run()
     // 画像処理を実行
     boundingBoxDetector.detect(frame, result);
 
+    // 検出失敗時はスキップする
+    if(!result.wasDetected) {
+      continue;
+    }
+
     // バウンディングボックスの中心X座標を計算
-    double centerX = (result.topLeft.x + result.bottomRight.x) / 2.0;
+    double currentX = (result.topLeft.x + result.bottomRight.x) / 2.0;
 
     // 旋回値の計算
-    double turningPower = pid.calculatePid(centerX) * edgeSign;
+    double turningPower = pid.calculatePid(currentX) * edgeSign;
 
     // モータのPower値をセット（前進の時0を下回らないように，後進の時0を上回らないようにセット）
     double rightPower = baseRightPower > 0.0 ? std::max(baseRightPower - turningPower, 0.0)

--- a/modules/motions/CameraPidTracking.cpp
+++ b/modules/motions/CameraPidTracking.cpp
@@ -1,17 +1,17 @@
 /**
  * @file   CameraPidTracking.cpp
- * @brief  カメラ画像を使ったPIDライントレースの親クラス
+ * @brief  カメラを使ったPID走行の親クラス
  * @author miyahara046 HaruArima08
  */
 
 #include "CameraPidTracking.h"
 
-CameraPidTracking::CameraPidTracking(Robot& _robot, double _targetSpeed, int _targetPoint,
+CameraPidTracking::CameraPidTracking(Robot& _robot, double _targetSpeed, int _targetXCoordinate,
                                      const PidGain& _pidGain,
                                      BoundingBoxDetector& _boundingBoxDetector)
   : Motion(_robot),
     targetSpeed(_targetSpeed),
-    targetPoint(_targetPoint),
+    targetXCoordinate(_targetXCoordinate),
     pidGain(_pidGain),
     boundingBoxDetector(_boundingBoxDetector)
 {
@@ -19,7 +19,7 @@ CameraPidTracking::CameraPidTracking(Robot& _robot, double _targetSpeed, int _ta
 
 void CameraPidTracking::run()
 {
-  Pid pid(pidGain.kp, pidGain.ki, pidGain.kd, targetPoint);
+  Pid pid(pidGain.kp, pidGain.ki, pidGain.kd, targetXCoordinate);
   // 事前条件を判定する
   if(!isMetPreCondition()) {
     return;

--- a/modules/motions/CameraPidTracking.cpp
+++ b/modules/motions/CameraPidTracking.cpp
@@ -1,0 +1,69 @@
+/**
+ * @file   CameraPidTracking.cpp
+ * @brief  カメラ画像を使ったPIDライントレースの親クラス
+ * @author miyahara046 HaruArima08
+ */
+
+#include "CameraPidTracking.h"
+
+CameraPidTracking::CameraPidTracking(Robot& _robot, double _targetSpeed, int _targetPoint,
+                                     const PidGain& _pidGain,
+                                     BoundingBoxDetector& _boundingBoxDetector)
+  : Motion(_robot),
+    targetSpeed(_targetSpeed),
+    targetPoint(_targetPoint),
+    pidGain(_pidGain),
+    boundingBoxDetector(_boundingBoxDetector)
+{
+}
+
+void CameraPidTracking::run()
+{
+  Pid pid(pidGain.kp, pidGain.ki, pidGain.kd, targetPoint);
+  // 事前条件を判定する
+  if(!isMetPreCondition()) {
+    return;
+  }
+
+  // 事前準備
+  prepare();
+
+  // 左右で符号を変える
+  int edgeSign = robot.getIsLeftEdge() ? -1 : 1;
+
+  SpeedCalculator speedCalculator(robot, targetSpeed);
+
+  // 継続条件を満たしている間ループ
+  while(isMetContinuationCondition()) {
+    // 初期Speed値を計算
+    double baseRightPower = speedCalculator.calculateRightMotorPower();
+    double baseLeftPower = speedCalculator.calculateLeftMotorPower();
+
+    // カメラからフレームを取得
+    cv::Mat frame;
+    robot.getCameraCaptureInstance().getFrame(frame);
+
+    // 画像処理を実行
+    boundingBoxDetector.detect(frame, result);
+
+    // バウンディングボックスの中心X座標を計算
+    double centerX = (result.topLeft.x + result.bottomRight.x) / 2.0;
+
+    // 旋回値の計算
+    double turningPower = pid.calculatePid(centerX) * edgeSign;
+
+    // モータのPower値をセット（前進の時0を下回らないように，後進の時0を上回らないようにセット）
+    double rightPower = baseRightPower > 0.0 ? std::max(baseRightPower - turningPower, 0.0)
+                                             : std::min(baseRightPower + turningPower, 0.0);
+    double leftPower = baseLeftPower > 0.0 ? std::max(baseLeftPower + turningPower, 0.0)
+                                           : std::min(baseLeftPower - turningPower, 0.0);
+    robot.getMotorControllerInstance().setRightMotorPower(rightPower);
+    robot.getMotorControllerInstance().setLeftMotorPower(leftPower);
+
+    // 10ms待機
+    robot.getClockInstance().sleep(10000);
+  }
+
+  // モータを停止
+  robot.getMotorControllerInstance().stopWheelsMotor();
+}

--- a/modules/motions/CameraPidTracking.h
+++ b/modules/motions/CameraPidTracking.h
@@ -1,0 +1,62 @@
+/**
+ * @file   CameraPidTracking.h
+ * @brief  カメラ画像を使ったPIDライントレースの親クラス
+ * @author miyahara046 HaruArima08
+ */
+
+#ifndef CAMERA_PID_TRACKING_H
+#define CAMERA_PID_TRACKING_H
+
+#include "Motion.h"
+#include "BoundingBoxDetector.h"
+#include "Pid.h"
+#include "SpeedCalculator.h"
+#include "Mileage.h"
+#include <algorithm>
+
+class CameraPidTracking : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   * @brief カメラ画像を使ったPIDライントレースクラスを初期化する
+   * @param _robot ロボットインスタンス
+   * @param _targetSpeed 目標速度
+   * @param _targetPoint 目標点
+   * @param _pidGain PIDゲイン
+   * @param _boundingBoxDetector 画像処理クラスのポインタ
+   */
+  CameraPidTracking(Robot& _robot, double _targetSpeed, int _targetPoint, const PidGain& _pidGain,
+                    BoundingBoxDetector& _boundingBoxDetector);
+
+  /**
+   * @brief ライントレースを実行する
+   */
+  void run() override;
+
+ protected:
+  /**
+   * @brief ライントレースする際の事前条件判定をする
+   */
+  virtual bool isMetPreCondition() = 0;
+
+  /**
+   * @brief ライントレースする際の事前処理をする
+   */
+  virtual void prepare() = 0;
+
+  /**
+   * @brief ライントレースする際の継続条件判定をする。返り値がfalseでモーターが止まる
+   */
+  virtual bool isMetContinuationCondition() = 0;
+
+ protected:
+  BoundingBoxDetector& boundingBoxDetector;  // 画像処理クラスの参照
+  // FormatCheck用の改行
+  BoundingBoxDetectionResult result;  // バウンディングボックスの座標を格納する構造体
+  // FormatCheck用の改行
+  double targetSpeed;  // 目標速度
+  int targetPoint;     // 目標X座標
+  PidGain pidGain;     // PIDゲイン
+};
+
+#endif

--- a/modules/motions/CameraPidTracking.h
+++ b/modules/motions/CameraPidTracking.h
@@ -1,6 +1,6 @@
 /**
  * @file   CameraPidTracking.h
- * @brief  カメラ画像を使ったPIDライントレースの親クラス
+ * @brief  カメラ画像を使ったPID走行の親クラス
  * @author miyahara046 HaruArima08
  */
 
@@ -18,7 +18,7 @@ class CameraPidTracking : public Motion {
  public:
   /**
    * コンストラクタ
-   * @brief カメラ画像を使ったPIDライントレースクラスを初期化する
+   * @brief カメラ画像を使ったPID走行クラスを初期化する
    * @param _robot ロボットインスタンス
    * @param _targetSpeed 目標速度
    * @param _targetPoint 目標点
@@ -29,34 +29,32 @@ class CameraPidTracking : public Motion {
                     BoundingBoxDetector& _boundingBoxDetector);
 
   /**
-   * @brief ライントレースを実行する
+   * @brief カメラ走行を実行する
    */
   void run() override;
 
  protected:
   /**
-   * @brief ライントレースする際の事前条件判定をする
+   * @brief カメラ走行する際の事前条件判定をする
    */
   virtual bool isMetPreCondition() = 0;
 
   /**
-   * @brief ライントレースする際の事前処理をする
+   * @brief カメラ走行する際の事前処理をする
    */
   virtual void prepare() = 0;
 
   /**
-   * @brief ライントレースする際の継続条件判定をする。返り値がfalseでモーターが止まる
+   * @brief カメラ走行する際の継続条件判定をする。返り値がfalseでモーターが止まる
    */
   virtual bool isMetContinuationCondition() = 0;
 
  protected:
   BoundingBoxDetector& boundingBoxDetector;  // 画像処理クラスの参照
-  // FormatCheck用の改行
   BoundingBoxDetectionResult result;  // バウンディングボックスの座標を格納する構造体
-  // FormatCheck用の改行
-  double targetSpeed;  // 目標速度
-  int targetPoint;     // 目標X座標
-  PidGain pidGain;     // PIDゲイン
+  double targetSpeed;                 // 目標速度
+  int targetPoint;                    // 目標X座標
+  PidGain pidGain;                    // PIDゲイン
 };
 
 #endif

--- a/modules/motions/CameraPidTracking.h
+++ b/modules/motions/CameraPidTracking.h
@@ -1,6 +1,6 @@
 /**
  * @file   CameraPidTracking.h
- * @brief  カメラ画像を使ったPID走行の親クラス
+ * @brief  カメラを使ったPID走行の親クラス
  * @author miyahara046 HaruArima08
  */
 
@@ -21,12 +21,12 @@ class CameraPidTracking : public Motion {
    * @brief カメラ画像を使ったPID走行クラスを初期化する
    * @param _robot ロボットインスタンス
    * @param _targetSpeed 目標速度
-   * @param _targetPoint 目標点
+   * @param _targetXCoordinate 目標x座標
    * @param _pidGain PIDゲイン
    * @param _boundingBoxDetector 画像処理クラスのポインタ
    */
-  CameraPidTracking(Robot& _robot, double _targetSpeed, int _targetPoint, const PidGain& _pidGain,
-                    BoundingBoxDetector& _boundingBoxDetector);
+  CameraPidTracking(Robot& _robot, double _targetSpeed, int _targetXCoordinate,
+                    const PidGain& _pidGain, BoundingBoxDetector& _boundingBoxDetector);
 
   /**
    * @brief カメラ走行を実行する
@@ -53,7 +53,7 @@ class CameraPidTracking : public Motion {
   BoundingBoxDetector& boundingBoxDetector;  // 画像処理クラスの参照
   BoundingBoxDetectionResult result;  // バウンディングボックスの座標を格納する構造体
   double targetSpeed;                 // 目標速度
-  int targetPoint;                    // 目標X座標
+  int targetXCoordinate;              // 目標X座標
   PidGain pidGain;                    // PIDゲイン
 };
 

--- a/modules/motions/DistanceCameraLineTrace.cpp
+++ b/modules/motions/DistanceCameraLineTrace.cpp
@@ -1,0 +1,63 @@
+/**
+ * @file   DistanceCameraLineTrace.cpp
+ * @brief  指定距離カメラライントレース動作
+ * @author miyahara046 HaruArima08
+ */
+
+#include "DistanceCameraLineTrace.h"
+
+DistanceCameraLineTrace::DistanceCameraLineTrace(Robot& _robot, double _targetDistance,
+                                                 double _targetSpeed, int _targetPoint,
+                                                 const PidGain& _pidGain,
+                                                 BoundingBoxDetector& _boundingBoxDetector)
+  : CameraPidTracking(_robot, _targetSpeed, _targetPoint, _pidGain, _boundingBoxDetector),
+    targetDistance(_targetDistance)
+{
+}
+
+// 指定距離カメラライントレースの事前条件
+bool DistanceCameraLineTrace::isMetPreCondition()
+{
+  // targetSpeed値が0の場合は終了する
+  if(targetSpeed == 0.0) {
+    return false;
+  }
+
+  // targetDistance値が0以下の場合は終了する
+  if(targetDistance <= 0.0) {
+    return false;
+  }
+
+  return true;
+}
+
+// 指定距離カメラライントレースの事前処理
+void DistanceCameraLineTrace::prepare()
+{
+  // 初期値を代入
+  initDistance = Mileage::calculateMileage(robot.getMotorControllerInstance().getRightMotorCount(),
+                                           robot.getMotorControllerInstance().getLeftMotorCount());
+}
+
+// 指定距離カメラライントレースの継続条件
+bool DistanceCameraLineTrace::isMetContinuationCondition()
+{
+  // フレーム取得をJUDGE_COUNT回数以上失敗するとモータが止まる
+  cv::Mat frame;
+  if(!robot.getCameraCaptureInstance().getFrame(frame) || frame.empty()) {
+    frameCount++;
+    if(frameCount >= JUDGE_COUNT) {
+      return false;
+    }
+  } else {
+    frameCount = 0;
+  }
+  // 走行距離が目標距離に到達するとモータが止まる
+  if(fabs(Mileage::calculateMileage(robot.getMotorControllerInstance().getRightMotorCount(),
+                                    robot.getMotorControllerInstance().getLeftMotorCount())
+          - initDistance)
+     >= targetDistance)
+    return false;
+
+  return true;
+}

--- a/modules/motions/DistanceCameraLineTrace.h
+++ b/modules/motions/DistanceCameraLineTrace.h
@@ -8,7 +8,6 @@
 #define DISTANCE_CAMERA_LINE_TRACE_H
 
 #include "CameraPidTracking.h"
-#include <memory>
 
 class DistanceCameraLineTrace : public CameraPidTracking {
  public:

--- a/modules/motions/DistanceCameraLineTrace.h
+++ b/modules/motions/DistanceCameraLineTrace.h
@@ -1,0 +1,59 @@
+/**
+ * @file   DistanceCameraLineTrace.h
+ * @brief  指定距離カメラライントレース動作
+ * @author miyahara046 HaruArima08
+ */
+
+#ifndef DISTANCE_CAMERA_LINE_TRACE_H
+#define DISTANCE_CAMERA_LINE_TRACE_H
+
+#include "CameraPidTracking.h"
+
+class DistanceCameraLineTrace : public CameraPidTracking {
+ public:
+  /**
+   * コンストラクタ
+   * @param _targetDistance 目標距離
+   * @param _targetSpeed 目標速度
+   * @param _targetPoint 目標x座標
+   * @param _pidGain PIDゲイン
+   * @param _boundingBoxDetector 画像処理クラスのポインタ
+   */
+  DistanceCameraLineTrace(Robot& _robot, double _targetDistance, double _targetSpeed,
+                          int _targetPoint, const PidGain& _pidGain,
+                          BoundingBoxDetector& _boundingBoxDetector);
+
+  /**
+   * @brief 指定距離だけカメラライントレースする
+   */
+  using CameraPidTracking::run;
+
+ protected:
+  /**
+   * @brief 指定距離カメラライントレースする際の事前条件判定をする
+   * @param targetSpeed 目標速度
+   */
+
+  bool isMetPreCondition() override;
+
+  /**
+   * @brief ライントレースする際の事前処理をする
+   */
+  void prepare() override;
+
+  /**
+   * @brief
+   * 指定距離カメラライントレースする際の継続条件判定をする。返り値がfalseでモーターが止まる
+   */
+  bool isMetContinuationCondition() override;
+
+ private:
+  static constexpr int JUDGE_COUNT = 3;  // フレーム取得最大失敗回数
+  // format check用
+  double targetDistance;  // 目標距離
+  double initDistance;    // 実行前の走行距離
+  // format check用
+  int frameCount;  // フレーム取得カウント
+};
+
+#endif

--- a/modules/motions/DistanceCameraLineTrace.h
+++ b/modules/motions/DistanceCameraLineTrace.h
@@ -8,6 +8,7 @@
 #define DISTANCE_CAMERA_LINE_TRACE_H
 
 #include "CameraPidTracking.h"
+#include <memory>
 
 class DistanceCameraLineTrace : public CameraPidTracking {
  public:
@@ -15,13 +16,13 @@ class DistanceCameraLineTrace : public CameraPidTracking {
    * コンストラクタ
    * @param _targetDistance 目標距離
    * @param _targetSpeed 目標速度
-   * @param _targetPoint 目標x座標
+   * @param _targetXCoordinate 目標x座標
    * @param _pidGain PIDゲイン
-   * @param _boundingBoxDetector 画像処理クラスのポインタ
+   * @param _detector 画像処理クラスのポインタ
    */
   DistanceCameraLineTrace(Robot& _robot, double _targetDistance, double _targetSpeed,
-                          int _targetPoint, const PidGain& _pidGain,
-                          BoundingBoxDetector& _boundingBoxDetector);
+                          int _targetXCoordinate, const PidGain& _pidGain,
+                          std::unique_ptr<BoundingBoxDetector> _detector);
 
   /**
    * @brief 指定距離だけカメラライントレースする
@@ -31,7 +32,6 @@ class DistanceCameraLineTrace : public CameraPidTracking {
  protected:
   /**
    * @brief 指定距離カメラライントレースする際の事前条件判定をする
-   * @param targetSpeed 目標速度
    */
 
   bool isMetPreCondition() override;
@@ -43,17 +43,16 @@ class DistanceCameraLineTrace : public CameraPidTracking {
 
   /**
    * @brief
-   * 指定距離カメラライントレースする際の継続条件判定をする。返り値がfalseでモーターが止まる
+   * 指定距離カメラライントレースする際の継続条件判定をする。
    */
   bool isMetContinuationCondition() override;
 
  private:
-  static constexpr int JUDGE_COUNT = 3;  // フレーム取得最大失敗回数
-  // format check用
-  double targetDistance;  // 目標距離
-  double initDistance;    // 実行前の走行距離
-  // format check用
-  int frameCount;  // フレーム取得カウント
+  static constexpr int JUDGE_COUNT = 3;           // フレーム取得最大失敗回数
+  double targetDistance;                          // 目標距離
+  double initDistance;                            // 実行前の走行距離
+  int frameCount = 0;                             // フレーム取得カウント
+  std::unique_ptr<BoundingBoxDetector> detector;  // 画像処理クラスのポインタ
 };
 
 #endif

--- a/modules/motions/EdgeChange.cpp
+++ b/modules/motions/EdgeChange.cpp
@@ -11,7 +11,6 @@ EdgeChange::EdgeChange(Robot& _robot, const bool& _isLeftEdge)
 {
 }
 
-// エッジを指定した値へ変更
 void EdgeChange::run()
 {
   robot.setIsLeftEdge(isLeftEdge);

--- a/modules/motions/Sleeping.h
+++ b/modules/motions/Sleeping.h
@@ -13,6 +13,7 @@ class Sleeping : public Motion {
  public:
   /**
    * コンストラクタ
+   * @param _robot ロボットのインスタンス
    * @param _microSec スリープ時間 (マイクロ秒)
    */
   Sleeping(Robot& _robot, int _microSec);
@@ -20,7 +21,7 @@ class Sleeping : public Motion {
   /**
    * @brief 自タスクスリープする
    */
-  void run();
+  void run() override;
 
  private:
   int microSec;  // スリープ時間 (マイクロ秒)

--- a/modules/motions/Sleeping.h
+++ b/modules/motions/Sleeping.h
@@ -20,6 +20,7 @@ class Sleeping : public Motion {
 
   /**
    * @brief 自タスクスリープする
+   * @note オーバーライド必須
    */
   void run() override;
 

--- a/modules/motions/Sleeping.h
+++ b/modules/motions/Sleeping.h
@@ -13,16 +13,14 @@ class Sleeping : public Motion {
  public:
   /**
    * コンストラクタ
-   * @param _robot ロボットのインスタンス
    * @param _microSec スリープ時間 (マイクロ秒)
    */
   Sleeping(Robot& _robot, int _microSec);
 
   /**
    * @brief 自タスクスリープする
-   * @note オーバーライド必須
    */
-  void run() override;
+  void run();
 
  private:
   int microSec;  // スリープ時間 (マイクロ秒)

--- a/tests/DistanceCameraLineTraceTest.cpp
+++ b/tests/DistanceCameraLineTraceTest.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <memory>
 #include "DistanceCameraLineTrace.h"
 #include "DummyBoundingBoxDetector.h"
 #include "DummyCameraCapture.h"
@@ -22,9 +23,10 @@ namespace etrobocon2025_test {
     int targetPoint = 320;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    DummyBoundingBoxDetector detector;
+    auto detector = std::make_unique<DummyBoundingBoxDetector>();
 
-    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain,
+                                std::move(detector));
 
     double expected = targetDistance;
 
@@ -49,12 +51,13 @@ namespace etrobocon2025_test {
     int targetPoint = 320;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    DummyBoundingBoxDetector detector;
+    auto detector = std::make_unique<DummyBoundingBoxDetector>();
 
     // DummyCameraCaptureで3回連続失敗を設定
     cameraCapture.setFrameResults({ true, true, false, false, false });
 
-    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain,
+                                std::move(detector));
 
     dcl.run();  // ライントレースを実行
 
@@ -63,8 +66,8 @@ namespace etrobocon2025_test {
     int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
     double actual = Mileage::calculateMileage(rightCount, leftCount);
 
-    // 走行距離が目標距離の20%未満であることを確認
-    EXPECT_LT(actual, targetDistance * 0.2);
+    // 走行距離が目標距離未満であることを確認
+    EXPECT_LT(actual, targetDistance);
   }
 
   // targetSpeed値が0の時に終了するテストケース
@@ -77,9 +80,10 @@ namespace etrobocon2025_test {
     int targetPoint = 320;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    DummyBoundingBoxDetector detector;
+    auto detector = std::make_unique<DummyBoundingBoxDetector>();
 
-    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain,
+                                std::move(detector));
 
     double expected = 0.0;
     dcl.run();  // ライントレースを実行
@@ -102,9 +106,10 @@ namespace etrobocon2025_test {
     int targetPoint = 320;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    DummyBoundingBoxDetector detector;
+    auto detector = std::make_unique<DummyBoundingBoxDetector>();
 
-    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain,
+                                std::move(detector));
 
     double expected = 0.0;
 
@@ -128,9 +133,10 @@ namespace etrobocon2025_test {
     int targetPoint = 320;
     PidGain gain = { 0.1, 0.05, 0.05 };
 
-    DummyBoundingBoxDetector detector;
+    auto detector = std::make_unique<DummyBoundingBoxDetector>();
 
-    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain,
+                                std::move(detector));
 
     double expected = 0.0;
 

--- a/tests/DistanceCameraLineTraceTest.cpp
+++ b/tests/DistanceCameraLineTraceTest.cpp
@@ -11,7 +11,6 @@
 #include "DummyCameraCapture.h"
 
 #define ERROR 1.01  // 許容誤差の倍率
-
 namespace etrobocon2025_test {
   // 目標距離までカメラライントレースを行うテストケース
   TEST(DistanceCameraLineTraceTest, RunDetectCalled)

--- a/tests/DistanceCameraLineTraceTest.cpp
+++ b/tests/DistanceCameraLineTraceTest.cpp
@@ -1,0 +1,146 @@
+/**
+ * @file   DistanceCameraLineTraceTest.cpp
+ * @brief  DistanceCameraLineTraceクラスのテスト
+ * @author HaruArima08 miyahara046
+ */
+
+#include <gtest/gtest.h>
+#include "DistanceCameraLineTrace.h"
+#include "DummyBoundingBoxDetector.h"
+#include "DummyCameraCapture.h"
+
+#define ERROR 1.01  // 許容誤差の倍率
+
+namespace etrobocon2025_test {
+  // 目標距離までカメラライントレースを行うテストケース
+  TEST(DistanceCameraLineTraceTest, RunDetectCalled)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    double targetDistance = 1000.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 320;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    DummyBoundingBoxDetector detector;
+
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+
+    double expected = targetDistance;
+
+    dcl.run();  // ライントレースを実行
+
+    // カメラライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LE(expected, actual);  // ライントレース後に走行した距離が期待する走行距離以上である
+    EXPECT_GT(expected * ERROR, actual);  // ライントレース後に走行した距離が許容誤差未満である
+  }
+
+  // フレーム取得に指定回数以上失敗した場合に終了するテストケース
+  TEST(DistanceCameraLineTraceTest, RunStopFrameFailures)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    double targetDistance = 1000.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 320;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    DummyBoundingBoxDetector detector;
+
+    // DummyCameraCaptureで3回連続失敗を設定
+    cameraCapture.setFrameResults({ true, true, false, false, false });
+
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+
+    dcl.run();  // ライントレースを実行
+
+    // 実際の走行距離を取得
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    // 走行距離が目標距離の20%未満であることを確認
+    EXPECT_LT(actual, targetDistance * 0.2);
+  }
+
+  // targetSpeed値が0の時に終了するテストケース
+  TEST(DistanceCameraLineTraceTest, RunZeroSpeed)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    double targetDistance = 1000.0;
+    double targetSpeed = 0.0;
+    int targetPoint = 320;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    DummyBoundingBoxDetector detector;
+
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+
+    double expected = 0.0;
+    dcl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expected, actual);  // ライントレース前後で走行距離に変化はない
+  }
+
+  // targetDistance値が負の時に終了するテストケース
+  TEST(DistanceCameraLineTraceTest, RunMinusDistance)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    double targetDistance = -1000.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 320;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    DummyBoundingBoxDetector detector;
+
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+
+    double expected = 0.0;
+
+    dcl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expected, actual);  // ライントレース前後で走行距離に変化はない
+  }
+
+  // targetDistance値が0のとき終了するテストケース
+  TEST(DistanceCameraLineTraceTest, RunZeroDistance)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    double targetDistance = 0.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 320;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    DummyBoundingBoxDetector detector;
+
+    DistanceCameraLineTrace dcl(robot, targetDistance, targetSpeed, targetPoint, gain, detector);
+
+    double expected = 0.0;
+
+    dcl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expected, actual);  // ライントレース前後で走行距離に変化はない
+  }
+}  // namespace etrobocon2025_test

--- a/tests/RobotTest.cpp
+++ b/tests/RobotTest.cpp
@@ -23,8 +23,8 @@ namespace etrobocon2025_test {
   TEST(RobotTest, GetCameraCaptureInstanceReturnsReference)
   {
     Robot robot;
-    CameraCapture& cameraRef1 = robot.getCameraCaptureInstance();
-    CameraCapture& cameraRef2 = robot.getCameraCaptureInstance();
+    ICameraCapture& cameraRef1 = robot.getCameraCaptureInstance();
+    ICameraCapture& cameraRef2 = robot.getCameraCaptureInstance();
 
     EXPECT_EQ(&cameraRef1, &cameraRef2);
   }

--- a/tests/SnapshotTest.cpp
+++ b/tests/SnapshotTest.cpp
@@ -8,7 +8,8 @@
 #include "Snapshot.h"
 
 namespace etrobocon2025_test {
-  // CameraCaptureクラスがインスタンス化できるか確認するテスト
+
+  // Snapshotの()メソッドが実行できるか確認するテスト
   TEST(SnapshotTest, SnapshotInit)
   {
     Robot robot;

--- a/tests/SnapshotTest.cpp
+++ b/tests/SnapshotTest.cpp
@@ -8,14 +8,13 @@
 #include "Snapshot.h"
 
 namespace etrobocon2025_test {
-
-  // Snapshotのrun()メソッドが実行できるか確認するテスト
+  // CameraCaptureクラスがインスタンス化できるか確認するテスト
   TEST(SnapshotTest, SnapshotInit)
   {
     Robot robot;
     Snapshot snapshot(robot, "test_snapshot");
 
+    // Snapshotのインスタンスが正常に作成されたか確認
     EXPECT_NO_THROW(snapshot.run());
   }
-
 }  // namespace etrobocon2025_test

--- a/tests/SnapshotTest.cpp
+++ b/tests/SnapshotTest.cpp
@@ -9,7 +9,7 @@
 
 namespace etrobocon2025_test {
 
-  // Snapshotの()メソッドが実行できるか確認するテスト
+  // Snapshotのrun()メソッドが実行できるか確認するテスト
   TEST(SnapshotTest, SnapshotInit)
   {
     Robot robot;

--- a/tests/SpeedCalculatorTest.cpp
+++ b/tests/SpeedCalculatorTest.cpp
@@ -1,6 +1,6 @@
 /**
  * @file SpeedCalculatorTest.cpp
- * @brief SpeedCalculatorクラスをテストする
+ * @brief SpeedCalculatorクラスのテスト
  * @author miyahara046
  */
 
@@ -9,79 +9,48 @@
 
 namespace etrobocon2025_test {
 
-  // LeftMotorに少しでもPower値が入っているかのテスト
-  TEST(SpeedCalculatorTest, CalculateLeftMotorPower)
+  // 左右のモーターに少しでもPower値が入っているかのテスト
+  TEST(SpeedCalculatorTest, CalculateMotorPower)
   {
     Robot robot;
     // Powerの初期化
     robot.getMotorControllerInstance().setRightMotorPower(0.0);
     robot.getMotorControllerInstance().setLeftMotorPower(0.0);
     SpeedCalculator speedCalculator(robot, 300.0);
-    double actualPower = speedCalculator.calculateLeftMotorPower();
+    double actualLeftPower = speedCalculator.calculateLeftMotorPower();
+    double actualRightPower = speedCalculator.calculateRightMotorPower();
     double expected = 0.0;
-    EXPECT_LT(expected, actualPower);
-  }
-  // RightMotorに少しでもPower値が入っているかのテスト
-  TEST(SpeedCalculatorTest, CalculateRightMotorPower)
-  {
-    Robot robot;
-    // Powerの初期化
-    robot.getMotorControllerInstance().setRightMotorPower(0.0);
-    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
-    SpeedCalculator speedCalculator(robot, 300.0);
-    double actualPower = speedCalculator.calculateRightMotorPower();
-    double expected = 0.0;
-    EXPECT_LT(expected, actualPower);
+    EXPECT_LT(expected, actualLeftPower);
+    EXPECT_LT(expected, actualRightPower);
   }
 
-  // LeftMotorに少しでも負のPower値が入っているかのテスト
-  TEST(SpeedCalculatorTest, CalculateLeftMotorPoewerFromMinusSpeed)
+  // 左右のモーターに少しでも負のPower値が入っているかのテスト
+  TEST(SpeedCalculatorTest, CalculateMotorPoewerFromMinusSpeed)
   {
     Robot robot;
     // Powerの初期化
     robot.getMotorControllerInstance().setRightMotorPower(0.0);
     robot.getMotorControllerInstance().setLeftMotorPower(0.0);
     SpeedCalculator speedCalculator(robot, -300.0);
-    double actualPower = speedCalculator.calculateLeftMotorPower();
+    double actualLeftPower = speedCalculator.calculateLeftMotorPower();
+    double actualRightPower = speedCalculator.calculateRightMotorPower();
     double expected = 0.0;
-    EXPECT_GT(expected, actualPower);
+    EXPECT_GT(expected, actualLeftPower);
+    EXPECT_GT(expected, actualRightPower);
   }
-  // RightMotorに少しでも負のPower値が入っているかのテスト
-  TEST(SpeedCalculatorTest, CalculateRightMotorPoewerFromMinusSpeed)
-  {
-    Robot robot;
-    // Powerの初期化
-    robot.getMotorControllerInstance().setRightMotorPower(0.0);
-    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
-    SpeedCalculator speedCalculator(robot, -300.0);
-    double actualPower = speedCalculator.calculateRightMotorPower();
-    double expected = 0.0;
-    EXPECT_GT(expected, actualPower);
-  }
-  // LeftMotorにPower値が入っていないかのテスト
-  TEST(SpeedCalculatorTest, CalculateLeftMotorPowerFromZeroSpeed)
+
+  // 左右のモータ―にPower値が入っていないかのテスト
+  TEST(SpeedCalculatorTest, CalculateMotorPowerFromZeroSpeed)
   {
     Robot robot;
     // Powerの初期化
     robot.getMotorControllerInstance().setRightMotorPower(0.0);
     robot.getMotorControllerInstance().setLeftMotorPower(0.0);
     SpeedCalculator speedCalculator(robot, 0.0);
-    double actualPower = speedCalculator.calculateLeftMotorPower();
+    double actualLeftPower = speedCalculator.calculateLeftMotorPower();
+    double actualRightPower = speedCalculator.calculateRightMotorPower();
     double expected = 0.0;
-    EXPECT_EQ(expected, actualPower);
+    EXPECT_EQ(expected, actualLeftPower);
+    EXPECT_EQ(expected, actualRightPower);
   }
-
-  // RightMotorにPower値が入っていないかのテスト
-  TEST(SpeedCalculatorTest, CalculateRightMotorPowerFromZeroSpeed)
-  {
-    Robot robot;
-    // Powerの初期化
-    robot.getMotorControllerInstance().setRightMotorPower(0.0);
-    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
-    SpeedCalculator speedCalculator(robot, 0.0);
-    double actualPower = speedCalculator.calculateRightMotorPower();
-    double expected = 0.0;
-    EXPECT_EQ(expected, actualPower);
-  }
-
 }  // namespace etrobocon2025_test

--- a/tests/SpeedCalculatorTest.cpp
+++ b/tests/SpeedCalculatorTest.cpp
@@ -1,0 +1,87 @@
+/**
+ * @file SpeedCalculatorTest.cpp
+ * @brief SpeedCalculatorクラスをテストする
+ * @author miyahara046
+ */
+
+#include "SpeedCalculator.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2025_test {
+
+  // LeftMotorに少しでもPower値が入っているかのテスト
+  TEST(SpeedCalculatorTest, CalculateLeftMotorPower)
+  {
+    Robot robot;
+    // Powerの初期化
+    robot.getMotorControllerInstance().setRightMotorPower(0.0);
+    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
+    SpeedCalculator speedCalculator(robot, 300.0);
+    double actualPower = speedCalculator.calculateLeftMotorPower();
+    double expected = 0.0;
+    EXPECT_LT(expected, actualPower);
+  }
+  // RightMotorに少しでもPower値が入っているかのテスト
+  TEST(SpeedCalculatorTest, CalculateRightMotorPower)
+  {
+    Robot robot;
+    // Powerの初期化
+    robot.getMotorControllerInstance().setRightMotorPower(0.0);
+    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
+    SpeedCalculator speedCalculator(robot, 300.0);
+    double actualPower = speedCalculator.calculateRightMotorPower();
+    double expected = 0.0;
+    EXPECT_LT(expected, actualPower);
+  }
+
+  // LeftMotorに少しでも負のPower値が入っているかのテスト
+  TEST(SpeedCalculatorTest, CalculateLeftMotorPoewerFromMinusSpeed)
+  {
+    Robot robot;
+    // Powerの初期化
+    robot.getMotorControllerInstance().setRightMotorPower(0.0);
+    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
+    SpeedCalculator speedCalculator(robot, -300.0);
+    double actualPower = speedCalculator.calculateLeftMotorPower();
+    double expected = 0.0;
+    EXPECT_GT(expected, actualPower);
+  }
+  // RightMotorに少しでも負のPower値が入っているかのテスト
+  TEST(SpeedCalculatorTest, CalculateRightMotorPoewerFromMinusSpeed)
+  {
+    Robot robot;
+    // Powerの初期化
+    robot.getMotorControllerInstance().setRightMotorPower(0.0);
+    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
+    SpeedCalculator speedCalculator(robot, -300.0);
+    double actualPower = speedCalculator.calculateRightMotorPower();
+    double expected = 0.0;
+    EXPECT_GT(expected, actualPower);
+  }
+  // LeftMotorにPower値が入っていないかのテスト
+  TEST(SpeedCalculatorTest, CalculateLeftMotorPowerFromZeroSpeed)
+  {
+    Robot robot;
+    // Powerの初期化
+    robot.getMotorControllerInstance().setRightMotorPower(0.0);
+    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
+    SpeedCalculator speedCalculator(robot, 0.0);
+    double actualPower = speedCalculator.calculateLeftMotorPower();
+    double expected = 0.0;
+    EXPECT_EQ(expected, actualPower);
+  }
+
+  // RightMotorにPower値が入っていないかのテスト
+  TEST(SpeedCalculatorTest, CalculateRightMotorPowerFromZeroSpeed)
+  {
+    Robot robot;
+    // Powerの初期化
+    robot.getMotorControllerInstance().setRightMotorPower(0.0);
+    robot.getMotorControllerInstance().setLeftMotorPower(0.0);
+    SpeedCalculator speedCalculator(robot, 0.0);
+    double actualPower = speedCalculator.calculateRightMotorPower();
+    double expected = 0.0;
+    EXPECT_EQ(expected, actualPower);
+  }
+
+}  // namespace etrobocon2025_test

--- a/tests/dummy/DummyBoundingBoxDetector.h
+++ b/tests/dummy/DummyBoundingBoxDetector.h
@@ -1,0 +1,27 @@
+/**
+ * @file DummyBoundingBoxDetector.h
+ * @brief 画像処理の親クラス(ダミー)
+ * @author HaruArima08 miyahara046
+ */
+
+#ifndef DUMMY_BOUNDING_BOX_DETECTOR_H
+#define DUMMY_BOUNDING_BOX_DETECTOR_H
+
+class DummyBoundingBoxDetector : public BoundingBoxDetector {
+ public:
+  /**
+   * @brief 物体検出を実行する純粋仮想関数
+   * @param frame 処理対象の画像フレーム
+   * @param result 結果を格納するBoundingBoxDetectionResult構造体の参照
+   */
+  void detect(const cv::Mat&, BoundingBoxDetectionResult& result) override
+  {
+    result.wasDetected = true;
+    result.topLeft = cv::Point(100, 100);
+    result.topRight = cv::Point(200, 100);
+    result.bottomLeft = cv::Point(100, 200);
+    result.bottomRight = cv::Point(200, 200);
+  }
+};
+
+#endif

--- a/tests/dummy/DummyCameraCapture.h
+++ b/tests/dummy/DummyCameraCapture.h
@@ -1,0 +1,73 @@
+/**
+ * @file   DummyCameraCapture.h
+ * @brief  カメラを制御するクラス（ダミー）
+ * @author HaruArima08 miyahara046
+ */
+
+#ifndef DUMMY_CAMERA_CAPTURE_H
+#define DUMMY_CAMERA_CAPTURE_H
+
+#include "ICameraCapture.h"
+#include <queue>
+
+class DummyCameraCapture : public ICameraCapture {
+ public:
+  int findAvailableCameraID(int maxTested = 10) override { return 0; }
+  int getCameraID() override { return 0; }
+  bool setCameraID(int id) override { return true; }
+  bool openCamera() override { return true; }
+  void setCapProps(double width, double height) override {}
+  /**
+   * @brief フレーム取得の成功・失敗の順番を設定
+   */
+  void setFrameResults(const std::vector<bool>& results)
+  {
+    while(!frameResults.empty()) frameResults.pop();
+    for(bool r : results) frameResults.push(r);
+    hasCustomFlag = true;
+  }
+  /**
+   * @brief 1枚のカメラ画像を取得する
+   * @param outFrame 取得した画像を格納するcv::Mat参照
+   * @return 画像取得に成功した場合はtrue、失敗した場合はfalse
+   */
+  bool getFrame(cv::Mat& outFrame) override
+  {
+    if(hasCustomFlag) {
+      if(frameResults.empty()) {
+        outFrame = cv::Mat();
+        return false;
+      }
+      bool success = frameResults.front();
+      frameResults.pop();
+      if(success) {
+        outFrame = cv::Mat::zeros(480, 640, CV_8UC3);  // 黒画像
+        return true;
+      } else {
+        outFrame = cv::Mat();  // 空画像（失敗）
+        return false;
+      }
+    } else {
+      // デフォルトでは常に成功で黒画像を返す
+      outFrame = cv::Mat::zeros(480, 640, CV_8UC3);
+      return true;
+    }
+  }
+
+  bool getFrames(std::vector<cv::Mat>& frames, int numFrames, int millisecondInterval) override
+  {
+    return true;
+  }
+
+  bool saveFrame(const cv::Mat& frame, std::string filepath, std::string filename) override
+  {
+    return true;
+  }
+
+ private:
+  std::queue<bool> frameResults;  // フレーム取得の成功・失敗の順番を保持する
+  // format check用
+  bool hasCustomFlag = false;  // setFrameResults()で結果リストを設定したかどうかを表すフラグ
+};
+
+#endif

--- a/tests/dummy/DummyCameraCapture.h
+++ b/tests/dummy/DummyCameraCapture.h
@@ -66,7 +66,6 @@ class DummyCameraCapture : public ICameraCapture {
 
  private:
   std::queue<bool> frameResults;  // フレーム取得の成功・失敗の順番を保持する
-  // format check用
   bool hasCustomFlag = false;  // setFrameResults()で結果リストを設定したかどうかを表すフラグ
 };
 


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点

- カメラライントレースの子クラス指定距離カメラライントレースの実装
- 指定距離カメラライントレースのテスト追加とダミーの作成
- スピードカルキュレータの左右のPidゲインを固有値にできるように更新
- スピードカルキュレータのテストの追加
- モーションパーサーへのコマンドの追加
- CameraCaptureのインターフェースの追加

# 動作テスト

[Notionを参考](https://www.notion.so/uom-katlab/pid-210dd5b1cc188034b7abe21d59966c56?source=copy_link)
