### PR TITLE
#KL25-69 ミニフィグの判定システムの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # ディレクトリ
 bin
 datafiles/snapshots
-test/test_images
+tests/test_images
 
 # yoloモデル
 *.onnx

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 # ディレクトリ
 bin
 datafiles/snapshots
+test/test_images
+
+# yoloモデル
+*.onnx

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # ディレクトリ
 bin
 datafiles/snapshots
+datafiles/processed_images
 tests/test_images
 
 # yoloモデル

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test-exec:
 	else \
 		cd $(MAKEFILE_PATH)bin/build && \
 		mkdir -p etrobocon2025/datafiles/commands && \
+		mkdir -p etrobocon2025/datafiles/snapshots && \
 		cp ../../datafiles/commands/*.csv etrobocon2025/datafiles/commands && \
 		./etrobocon2025_test && \
 		rm -rf etrobocon2025; \

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-exec:
 	else \
 		cd $(MAKEFILE_PATH)bin/build && \
 		mkdir -p etrobocon2025/datafiles/commands && \
-		mkdir -p etrobocon2025/datafiles/snapshots && \
+		mkdir -p etrobocon2025/datafiles/processed_images && \
 		cp ../../datafiles/commands/*.csv etrobocon2025/datafiles/commands && \
 		./etrobocon2025_test && \
 		rm -rf etrobocon2025; \

--- a/modules/MiniFigDirectionDetector.cpp
+++ b/modules/MiniFigDirectionDetector.cpp
@@ -6,9 +6,8 @@
 
 #include "MiniFigDirectionDetector.h"
 
-MiniFigDirectionDetector::MiniFigDirectionDetector(const std::string& modelPath,
-                                                   const std::string& saveImagePath)
-  : modelPath(modelPath), saveImagePath(saveImagePath)
+MiniFigDirectionDetector::MiniFigDirectionDetector(const std::string& modelPath)
+  : modelPath(modelPath)
 {
   // ネットワークの読み込み
   net = cv::dnn::readNetFromONNX(modelPath);  // モデルのパスを設定する
@@ -21,8 +20,7 @@ MiniFigDirectionDetector::MiniFigDirectionDetector(const std::string& modelPath,
   net.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);       // CPUをターゲットに設定
 }
 
-void MiniFigDirectionDetector::detect(const cv::Mat& frame, /*const std::string& saveImagePath,*/
-                                      MiniFigDirectionResult& result)
+void MiniFigDirectionDetector::detect(const cv::Mat& frame, MiniFigDirectionResult& result)
 {
   // 入力画像の前処理
   cv::Mat blob = preprocess(frame);
@@ -33,7 +31,7 @@ void MiniFigDirectionDetector::detect(const cv::Mat& frame, /*const std::string&
   net.forward(outputs, net.getUnconnectedOutLayersNames());
 
   // 出力結果の後処理
-  postprocess(outputs, frame, result /*, saveImagePath*/);
+  postprocess(outputs, frame, result);
 }
 
 // 入力画像の前処理を行う関数
@@ -47,9 +45,9 @@ cv::Mat MiniFigDirectionDetector::preprocess(const cv::Mat& frame)
 
 // 出力結果を後処理して検出結果を生成する関数
 void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
-                                           const cv::Mat& frame, MiniFigDirectionResult& result/*,
-                                           const std::string& saveImagePath*/)
+                                           const cv::Mat& frame, MiniFigDirectionResult& result)
 {
+  // 推論結果からの抽出用データ構造を初期化
   std::vector<int> classIds;
   std::vector<float> confidences;
   std::vector<cv::Rect> boxes;
@@ -57,23 +55,28 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
   const float confThreshold = CONFIDENCE_THRESHOLD;
   const float nmsThreshold = NMS_THRESHOLD;
 
+  // 各出力（YOLOでは複数層出力）を走査
   for(const auto& output : outputs) {
     if(output.dims != 5) continue;
 
-    int numAnchors = output.size[1];
-    int gridHeight = output.size[2];
-    int gridWidth = output.size[3];
-    int attributes = output.size[4];
+    int numAnchors = output.size[1];  // 1グリッドセルあたりのアンカー数
+    int gridHeight = output.size[2];  // グリッドの高さ
+    int gridWidth = output.size[3];   // グリッドの幅
+    int attributes = output.size[4];  // 属性数
     const float* data = (float*)output.data;
 
+    // グリッド全体を走査(縦・横・アンカー)
     for(int y = 0; y < gridHeight; ++y) {
       for(int x = 0; x < gridWidth; ++x) {
         for(int anchor = 0; anchor < numAnchors; ++anchor) {
+          // 5次元配列の中で対象データのインデックスを計算
           int idx = ((anchor * gridHeight + y) * gridWidth + x) * attributes;
 
+          // 信頼度が閾値未満の場合はスキップ
           float conf = data[idx + 4];
           if(conf < confThreshold) continue;
 
+          // クラススコアをMatとして取得し、最大スコアとそのクラスIDを求める
           float* classScores = (float*)&data[idx + 5];
           cv::Mat scores(1, attributes - 5, CV_32FC1, classScores);
           cv::Point classIdPoint;
@@ -81,6 +84,7 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
           cv::minMaxLoc(scores, 0, &maxScore, 0, &classIdPoint);
 
           if(maxScore > confThreshold) {
+            // バウンディングボックス中心座標とサイズを取得
             float cx = data[idx + 0];
             float cy = data[idx + 1];
             float w = data[idx + 2];
@@ -107,6 +111,7 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
     return;
   }
 
+  // 非最大抑制(NMS)を適用し、最も信頼度の高い検出結果を選別
   std::vector<int> indices;
   cv::dnn::NMSBoxes(boxes, confidences, confThreshold, nmsThreshold, indices);
 
@@ -115,8 +120,10 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
     return;
   }
 
+  // 最も信頼度の高い検出結果を使って方向を決定
   int bestIdx = indices[0];
 
+  // classIdsからミニフィグの向きを決定
   if(classIds[bestIdx] == 0) {
     result.direction = MiniFigDirection::FRONT;
   } else if(classIds[bestIdx] == 1) {
@@ -138,7 +145,7 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
     cv::putText(outputImage, label, boxes[idx].tl(), cv::FONT_HERSHEY_SIMPLEX, 0.5,
                 cv::Scalar(255, 0, 0), 1);
   }
-  cv::imwrite(saveImagePath, outputImage);
+  cv::imwrite("etrobocon2025/datafiles/snapshots/detected_result.jpg", outputImage);
 
   // 検出された方向クラスIDを表示
   std::cout << "検出された方向クラスID: " << static_cast<int>(result.direction) << std::endl;

--- a/modules/MiniFigDirectionDetector.cpp
+++ b/modules/MiniFigDirectionDetector.cpp
@@ -6,7 +6,9 @@
 
 #include "MiniFigDirectionDetector.h"
 
-MiniFigDirectionDetector::MiniFigDirectionDetector(const std::string& modelPath)
+MiniFigDirectionDetector::MiniFigDirectionDetector(const std::string& modelPath,
+                                                   const std::string& saveImagePath)
+  : modelPath(modelPath), saveImagePath(saveImagePath)
 {
   // ネットワークの読み込み
   net = cv::dnn::readNetFromONNX(modelPath);  // モデルのパスを設定する
@@ -19,7 +21,7 @@ MiniFigDirectionDetector::MiniFigDirectionDetector(const std::string& modelPath)
   net.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);       // CPUをターゲットに設定
 }
 
-void MiniFigDirectionDetector::detect(const cv::Mat& frame, const std::string& saveImagePath,
+void MiniFigDirectionDetector::detect(const cv::Mat& frame, /*const std::string& saveImagePath,*/
                                       MiniFigDirectionResult& result)
 {
   // 入力画像の前処理
@@ -31,7 +33,7 @@ void MiniFigDirectionDetector::detect(const cv::Mat& frame, const std::string& s
   net.forward(outputs, net.getUnconnectedOutLayersNames());
 
   // 出力結果の後処理
-  postprocess(outputs, frame, result, saveImagePath);
+  postprocess(outputs, frame, result /*, saveImagePath*/);
 }
 
 // 入力画像の前処理を行う関数
@@ -45,8 +47,8 @@ cv::Mat MiniFigDirectionDetector::preprocess(const cv::Mat& frame)
 
 // 出力結果を後処理して検出結果を生成する関数
 void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
-                                           const cv::Mat& frame, MiniFigDirectionResult& result,
-                                           const std::string& saveImagePath)
+                                           const cv::Mat& frame, MiniFigDirectionResult& result/*,
+                                           const std::string& saveImagePath*/)
 {
   std::vector<int> classIds;
   std::vector<float> confidences;

--- a/modules/MiniFigDirectionDetector.cpp
+++ b/modules/MiniFigDirectionDetector.cpp
@@ -1,0 +1,138 @@
+/**
+ * @file   MinifigDirectionDetector.cpp
+ * @brief  ミニフィグの向きを検出するクラス
+ * @author nishijima515
+ */
+
+#include "MiniFigDirectionDetector.h"
+
+using namespace cv;
+using namespace dnn;
+
+MiniFigDirectionDetector::MiniFigDirectionDetector(const std::string& modelPath)
+{
+  // コンストラクタの実装
+  // ネットワークの読み込み
+  net = readNetFromONNX(modelPath);  // モデルのパスを設定する
+  if(net.empty()) {
+    std::cerr << "モデルの読み込みに失敗しました！" << std::endl;
+  } else {
+    std::cout << "モデルが正常に読み込まれました。" << std::endl;
+  }
+  net.setPreferableBackend(DNN_BACKEND_OPENCV);  // OpenCVバックエンドを使用
+  net.setPreferableTarget(DNN_TARGET_CPU);       // CPUをターゲットに設定
+}
+
+MiniFigDirectionResult MiniFigDirectionDetector::detect(const cv::Mat& frame)
+{
+  MiniFigDirectionResult result;
+
+  // 入力画像の前処理
+  Mat blob = preprocess(frame);
+  net.setInput(blob);
+
+  // ネットワークの推論を実行
+  std::vector<Mat> outputs;
+  net.forward(outputs, net.getUnconnectedOutLayersNames());
+
+  // 出力結果の後処理
+  postprocess(outputs, frame, result);
+
+  return result;
+}
+
+// 入力画像の前処理を行う関数
+cv::Mat MiniFigDirectionDetector::preprocess(const cv::Mat& frame)
+{
+  cv::Mat blob;
+  blobFromImage(frame, blob, 1.0 / 255.0, Size(640, 640), Scalar(), true, false);
+  return blob;
+}
+
+// 出力結果を後処理して検出結果を生成する関数
+void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
+                                           const cv::Mat& frame, MiniFigDirectionResult& result)
+{
+  std::vector<int> classIds;
+  std::vector<float> confidences;
+  std::vector<Rect> boxes;
+
+  const float confThreshold = CONFIDENCE_THRESHOLD;
+  const float nmsThreshold = NMS_THRESHOLD;
+
+  for(const auto& output : outputs) {
+    if(output.dims != 5) continue;
+
+    int numAnchors = output.size[1];
+    int gridHeight = output.size[2];
+    int gridWidth = output.size[3];
+    int attributes = output.size[4];
+    const float* data = (float*)output.data;
+
+    for(int y = 0; y < gridHeight; ++y) {
+      for(int x = 0; x < gridWidth; ++x) {
+        for(int anchor = 0; anchor < numAnchors; ++anchor) {
+          int idx = ((anchor * gridHeight + y) * gridWidth + x) * attributes;
+
+          float conf = data[idx + 4];
+          if(conf < confThreshold) continue;
+
+          float* classScores = (float*)&data[idx + 5];
+          Mat scores(1, attributes - 5, CV_32FC1, classScores);
+          Point classIdPoint;
+          double maxScore;
+          minMaxLoc(scores, 0, &maxScore, 0, &classIdPoint);
+
+          if(maxScore > confThreshold) {
+            float cx = data[idx + 0];
+            float cy = data[idx + 1];
+            float w = data[idx + 2];
+            float h = data[idx + 3];
+
+            int centerX = int(cx * frame.cols);
+            int centerY = int(cy * frame.rows);
+            int width = int(w * frame.cols);
+            int height = int(h * frame.rows);
+            int left = centerX - width / 2;
+            int top = centerY - height / 2;
+
+            boxes.emplace_back(left, top, width, height);
+            confidences.push_back(maxScore);
+            classIds.push_back(classIdPoint.x);
+          }
+        }
+      }
+    }
+  }
+
+  if(boxes.empty()) {
+    result.wasDetected = false;
+    return;
+  }
+
+  std::vector<int> indices;
+  NMSBoxes(boxes, confidences, confThreshold, nmsThreshold, indices);
+
+  if(indices.empty()) {
+    result.wasDetected = false;
+    return;
+  }
+
+  int bestIdx = indices[0];
+
+  int direction;
+  if(classIds[bestIdx] == 0) {
+    direction = 0;
+  } else if(classIds[bestIdx] == 1) {
+    direction = 2;
+  } else if(classIds[bestIdx] == 2) {
+    direction = 3;
+  } else if(classIds[bestIdx] == 3) {
+    direction = 1;
+  }
+
+  result.wasDetected = true;
+  result.direction = static_cast<MiniFigDirection>(direction);
+  // デバッグ出力を追加
+  std::cout << "検出された方向クラスID: " << direction << std::endl;
+}

--- a/modules/MiniFigDirectionDetector.cpp
+++ b/modules/MiniFigDirectionDetector.cpp
@@ -145,7 +145,7 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
     cv::putText(outputImage, label, boxes[idx].tl(), cv::FONT_HERSHEY_SIMPLEX, 0.5,
                 cv::Scalar(255, 0, 0), 1);
   }
-  cv::imwrite("etrobocon2025/datafiles/snapshots/detected_result.jpg", outputImage);
+  cv::imwrite(outputImagePath, outputImage);
 
   // 検出された方向クラスIDを表示
   std::cout << "検出された方向クラスID: " << static_cast<int>(result.direction) << std::endl;

--- a/modules/MiniFigDirectionDetector.cpp
+++ b/modules/MiniFigDirectionDetector.cpp
@@ -1,52 +1,45 @@
 /**
- * @file   MinifigDirectionDetector.cpp
+ * @file   MiniFigDirectionDetector.cpp
  * @brief  ミニフィグの向きを検出するクラス
  * @author nishijima515
  */
 
 #include "MiniFigDirectionDetector.h"
 
-using namespace cv;
-using namespace dnn;
-
 MiniFigDirectionDetector::MiniFigDirectionDetector(const std::string& modelPath)
 {
-  // コンストラクタの実装
   // ネットワークの読み込み
-  net = readNetFromONNX(modelPath);  // モデルのパスを設定する
+  net = cv::dnn::readNetFromONNX(modelPath);  // モデルのパスを設定する
   if(net.empty()) {
     std::cerr << "モデルの読み込みに失敗しました！" << std::endl;
   } else {
     std::cout << "モデルが正常に読み込まれました。" << std::endl;
   }
-  net.setPreferableBackend(DNN_BACKEND_OPENCV);  // OpenCVバックエンドを使用
-  net.setPreferableTarget(DNN_TARGET_CPU);       // CPUをターゲットに設定
+  net.setPreferableBackend(cv::dnn::DNN_BACKEND_OPENCV);  // OpenCVバックエンドを使用
+  net.setPreferableTarget(cv::dnn::DNN_TARGET_CPU);       // CPUをターゲットに設定
 }
 
-MiniFigDirectionResult MiniFigDirectionDetector::detect(const cv::Mat& frame,
-                                                        const std::string& saveImagePath)
+void MiniFigDirectionDetector::detect(const cv::Mat& frame, const std::string& saveImagePath,
+                                      MiniFigDirectionResult& result)
 {
-  MiniFigDirectionResult result;
-
   // 入力画像の前処理
-  Mat blob = preprocess(frame);
+  cv::Mat blob = preprocess(frame);
   net.setInput(blob);
 
   // ネットワークの推論を実行
-  std::vector<Mat> outputs;
+  std::vector<cv::Mat> outputs;
   net.forward(outputs, net.getUnconnectedOutLayersNames());
 
   // 出力結果の後処理
   postprocess(outputs, frame, result, saveImagePath);
-
-  return result;
 }
 
 // 入力画像の前処理を行う関数
+// 画像をモデルに合うサイズ(640x640）にリサイズし、画素値を0~1に正規化する
 cv::Mat MiniFigDirectionDetector::preprocess(const cv::Mat& frame)
 {
   cv::Mat blob;
-  blobFromImage(frame, blob, 1.0 / 255.0, Size(640, 640), Scalar(), true, false);
+  cv::dnn::blobFromImage(frame, blob, 1.0 / 255.0, cv::Size(640, 640), cv::Scalar(), true, false);
   return blob;
 }
 
@@ -57,7 +50,7 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
 {
   std::vector<int> classIds;
   std::vector<float> confidences;
-  std::vector<Rect> boxes;
+  std::vector<cv::Rect> boxes;
 
   const float confThreshold = CONFIDENCE_THRESHOLD;
   const float nmsThreshold = NMS_THRESHOLD;
@@ -80,10 +73,10 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
           if(conf < confThreshold) continue;
 
           float* classScores = (float*)&data[idx + 5];
-          Mat scores(1, attributes - 5, CV_32FC1, classScores);
-          Point classIdPoint;
+          cv::Mat scores(1, attributes - 5, CV_32FC1, classScores);
+          cv::Point classIdPoint;
           double maxScore;
-          minMaxLoc(scores, 0, &maxScore, 0, &classIdPoint);
+          cv::minMaxLoc(scores, 0, &maxScore, 0, &classIdPoint);
 
           if(maxScore > confThreshold) {
             float cx = data[idx + 0];
@@ -113,7 +106,7 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
   }
 
   std::vector<int> indices;
-  NMSBoxes(boxes, confidences, confThreshold, nmsThreshold, indices);
+  cv::dnn::NMSBoxes(boxes, confidences, confThreshold, nmsThreshold, indices);
 
   if(indices.empty()) {
     result.wasDetected = false;
@@ -122,19 +115,17 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
 
   int bestIdx = indices[0];
 
-  int direction;
   if(classIds[bestIdx] == 0) {
-    direction = 0;
+    result.direction = MiniFigDirection::FRONT;
   } else if(classIds[bestIdx] == 1) {
-    direction = 2;
+    result.direction = MiniFigDirection::BACK;
   } else if(classIds[bestIdx] == 2) {
-    direction = 3;
+    result.direction = MiniFigDirection::RIGHT;
   } else if(classIds[bestIdx] == 3) {
-    direction = 1;
+    result.direction = MiniFigDirection::LEFT;
   }
 
   result.wasDetected = true;
-  result.direction = static_cast<MiniFigDirection>(direction);
 
   // 検出結果を画像に描画
   cv::Mat outputImage = frame.clone();
@@ -148,5 +139,5 @@ void MiniFigDirectionDetector::postprocess(const std::vector<cv::Mat>& outputs,
   cv::imwrite(saveImagePath, outputImage);
 
   // 検出された方向クラスIDを表示
-  std::cout << "検出された方向クラスID: " << direction << std::endl;
+  std::cout << "検出された方向クラスID: " << static_cast<int>(result.direction) << std::endl;
 }

--- a/modules/MiniFigDirectionDetector.h
+++ b/modules/MiniFigDirectionDetector.h
@@ -18,7 +18,7 @@
 #define NMS_THRESHOLD 0.4         // 検出ボックス同士の重なりを判断する閾値
 
 // ミニフィグの向きを表す列挙体
-enum class MiniFigDirection { FRONT, LEFT, BACK, RIGHT };
+enum class MiniFigDirection { FRONT, RIGHT, BACK, LEFT };
 
 struct MiniFigDirectionResult {
   bool wasDetected = false;    // 検出が成功したかどうか

--- a/modules/MiniFigDirectionDetector.h
+++ b/modules/MiniFigDirectionDetector.h
@@ -22,7 +22,6 @@ using namespace dnn;
 
 // ミニフィグの向きを表す列挙体
 enum class MiniFigDirection { FRONT, LEFT, BACK, RIGHT };
-// enum class MiniFigDirection { FRONT, BACK, RIGHT, LEFT };
 
 struct MiniFigDirectionResult {
   bool wasDetected = false;    // 検出が成功したかどうか
@@ -36,20 +35,23 @@ class MiniFigDirectionDetector {
 
   // ミニフィグの向き検出を行う処理
   // MiniFigDirectionResult 型の構造体を返す
-  MiniFigDirectionResult detect(const cv::Mat& frame);
+  MiniFigDirectionResult detect(const cv::Mat& frame, const std::string& saveImagePath);
 
  private:
   cv::dnn::Net net;  // DNNモデルを格納する変数
+
   // モデルの前処理を行う関数
   cv::Mat preprocess(const cv::Mat& frame);
-  // 出力結果を後処理して検出結果を生成する関数
-  // outputs: ネットワークの出力結果
-  // frame: 入力画像フレーム
-  // result: 検出結果を格納する構造体
-  // result.wasDetected: 検出が成功したかどうか
-  // result.direction: ミニフィグの向きを表す列挙体
+
+  /**
+   * @brief 出力結果を後処理して検出結果を生成する関数
+   * @param outputs: ネットワークの出力結果
+   * @param frame: 入力画像フレーム
+   * @param result: 検出結果を格納する構造体
+   * @param saveImagePath: 検出結果を保存する画像のパス
+   */
   void postprocess(const std::vector<cv::Mat>& outputs, const cv::Mat& frame,
-                   MiniFigDirectionResult& result);
+                   MiniFigDirectionResult& result, const std::string& saveImagePath);
 };
 
 #endif  // MINIFIG_DIRECTION_DETECTOR_H

--- a/modules/MiniFigDirectionDetector.h
+++ b/modules/MiniFigDirectionDetector.h
@@ -38,7 +38,8 @@ class MiniFigDirectionDetector {
   cv::dnn::Net net;             // DNNモデルを格納する変数
   const std::string modelPath;  // モデルのパス
   const std::string outputImagePath
-      = "etrobocon2025/datafiles/snapshots/detected_result.jpg";  // バウンディングボックス付きの画像のパス
+      = "etrobocon2025/datafiles/processed_images/"
+        "fig_detected_result.jpg";  // バウンディングボックス付きの画像のパス
 
   // モデルの前処理を行う関数
   cv::Mat preprocess(const cv::Mat& frame);

--- a/modules/MiniFigDirectionDetector.h
+++ b/modules/MiniFigDirectionDetector.h
@@ -28,19 +28,15 @@ struct MiniFigDirectionResult {
 class MiniFigDirectionDetector {
  public:
   // コンストラクタ
-  MiniFigDirectionDetector(const std::string& modelPath = "etrobocon2025/yolo_optimized.onnx",
-                           const std::string& saveImagePath
-                           = "etrobocon2025/datafiles/snapshots/detected_result.jpg");
+  MiniFigDirectionDetector(const std::string& modelPath = "etrobocon2025/yolo_optimized.onnx");
 
   // ミニフィグの向き検出を行う処理
   // MiniFigDirectionResult 型の構造体を返す
-  void detect(const cv::Mat& frame, /*const std::string& saveImagePath,*/
-              MiniFigDirectionResult& result);
+  void detect(const cv::Mat& frame, MiniFigDirectionResult& result);
 
  private:
-  cv::dnn::Net net;                 // DNNモデルを格納する変数
-  const std::string modelPath;      // モデルのパス
-  const std::string saveImagePath;  // 検出結果を保存する画像のパス
+  cv::dnn::Net net;             // DNNモデルを格納する変数
+  const std::string modelPath;  // モデルのパス
 
   // モデルの前処理を行う関数
   cv::Mat preprocess(const cv::Mat& frame);
@@ -50,10 +46,9 @@ class MiniFigDirectionDetector {
    * @param outputs: ネットワークの出力結果
    * @param frame: 入力画像フレーム
    * @param result: 検出結果を格納する構造体
-   * @param saveImagePath: 検出結果を保存する画像のパス
    */
   void postprocess(const std::vector<cv::Mat>& outputs, const cv::Mat& frame,
-                   MiniFigDirectionResult& result /*, const std::string& saveImagePath*/);
+                   MiniFigDirectionResult& result);
 };
 
 #endif  // MINIFIG_DIRECTION_DETECTOR_H

--- a/modules/MiniFigDirectionDetector.h
+++ b/modules/MiniFigDirectionDetector.h
@@ -1,5 +1,5 @@
 /**
- * @file   MinifigDirectionDetector.h
+ * @file   MiniFigDirectionDetector.h
  * @brief  ミニフィグの向きを検出するクラス
  * @author nishijima515
  */
@@ -17,9 +17,6 @@
 #define CONFIDENCE_THRESHOLD 0.4  // 検出結果を採用する最低信頼度の閾値
 #define NMS_THRESHOLD 0.4         // 検出ボックス同士の重なりを判断する閾値
 
-using namespace cv;
-using namespace dnn;
-
 // ミニフィグの向きを表す列挙体
 enum class MiniFigDirection { FRONT, LEFT, BACK, RIGHT };
 
@@ -35,7 +32,8 @@ class MiniFigDirectionDetector {
 
   // ミニフィグの向き検出を行う処理
   // MiniFigDirectionResult 型の構造体を返す
-  MiniFigDirectionResult detect(const cv::Mat& frame, const std::string& saveImagePath);
+  void detect(const cv::Mat& frame, const std::string& saveImagePath,
+              MiniFigDirectionResult& result);
 
  private:
   cv::dnn::Net net;  // DNNモデルを格納する変数

--- a/modules/MiniFigDirectionDetector.h
+++ b/modules/MiniFigDirectionDetector.h
@@ -1,0 +1,55 @@
+/**
+ * @file   MinifigDirectionDetector.h
+ * @brief  ミニフィグの向きを検出するクラス
+ * @author nishijima515
+ */
+
+#ifndef MINIFIG_DIRECTION_DETECTOR_H
+#define MINIFIG_DIRECTION_DETECTOR_H
+
+#include <opencv2/opencv.hpp>
+#include <opencv2/dnn.hpp>
+#include <algorithm>
+#include <iostream>
+#include <vector>
+#include <string>
+
+#define CONFIDENCE_THRESHOLD 0.4  // 検出結果を採用する最低信頼度の閾値
+#define NMS_THRESHOLD 0.4         // 検出ボックス同士の重なりを判断する閾値
+
+using namespace cv;
+using namespace dnn;
+
+// ミニフィグの向きを表す列挙体
+enum class MiniFigDirection { FRONT, LEFT, BACK, RIGHT };
+// enum class MiniFigDirection { FRONT, BACK, RIGHT, LEFT };
+
+struct MiniFigDirectionResult {
+  bool wasDetected = false;    // 検出が成功したかどうか
+  MiniFigDirection direction;  // ミニフィグの向きを表す列挙体
+};
+
+class MiniFigDirectionDetector {
+ public:
+  // コンストラクタ
+  MiniFigDirectionDetector(const std::string& modelPath);
+
+  // ミニフィグの向き検出を行う処理
+  // MiniFigDirectionResult 型の構造体を返す
+  MiniFigDirectionResult detect(const cv::Mat& frame);
+
+ private:
+  cv::dnn::Net net;  // DNNモデルを格納する変数
+  // モデルの前処理を行う関数
+  cv::Mat preprocess(const cv::Mat& frame);
+  // 出力結果を後処理して検出結果を生成する関数
+  // outputs: ネットワークの出力結果
+  // frame: 入力画像フレーム
+  // result: 検出結果を格納する構造体
+  // result.wasDetected: 検出が成功したかどうか
+  // result.direction: ミニフィグの向きを表す列挙体
+  void postprocess(const std::vector<cv::Mat>& outputs, const cv::Mat& frame,
+                   MiniFigDirectionResult& result);
+};
+
+#endif  // MINIFIG_DIRECTION_DETECTOR_H

--- a/modules/MiniFigDirectionDetector.h
+++ b/modules/MiniFigDirectionDetector.h
@@ -28,15 +28,19 @@ struct MiniFigDirectionResult {
 class MiniFigDirectionDetector {
  public:
   // コンストラクタ
-  MiniFigDirectionDetector(const std::string& modelPath);
+  MiniFigDirectionDetector(const std::string& modelPath = "etrobocon2025/yolo_optimized.onnx",
+                           const std::string& saveImagePath
+                           = "etrobocon2025/datafiles/snapshots/detected_result.jpg");
 
   // ミニフィグの向き検出を行う処理
   // MiniFigDirectionResult 型の構造体を返す
-  void detect(const cv::Mat& frame, const std::string& saveImagePath,
+  void detect(const cv::Mat& frame, /*const std::string& saveImagePath,*/
               MiniFigDirectionResult& result);
 
  private:
-  cv::dnn::Net net;  // DNNモデルを格納する変数
+  cv::dnn::Net net;                 // DNNモデルを格納する変数
+  const std::string modelPath;      // モデルのパス
+  const std::string saveImagePath;  // 検出結果を保存する画像のパス
 
   // モデルの前処理を行う関数
   cv::Mat preprocess(const cv::Mat& frame);
@@ -49,7 +53,7 @@ class MiniFigDirectionDetector {
    * @param saveImagePath: 検出結果を保存する画像のパス
    */
   void postprocess(const std::vector<cv::Mat>& outputs, const cv::Mat& frame,
-                   MiniFigDirectionResult& result, const std::string& saveImagePath);
+                   MiniFigDirectionResult& result /*, const std::string& saveImagePath*/);
 };
 
 #endif  // MINIFIG_DIRECTION_DETECTOR_H

--- a/modules/MiniFigDirectionDetector.h
+++ b/modules/MiniFigDirectionDetector.h
@@ -37,6 +37,8 @@ class MiniFigDirectionDetector {
  private:
   cv::dnn::Net net;             // DNNモデルを格納する変数
   const std::string modelPath;  // モデルのパス
+  const std::string outputImagePath
+      = "etrobocon2025/datafiles/snapshots/detected_result.jpg";  // バウンディングボックス付きの画像のパス
 
   // モデルの前処理を行う関数
   cv::Mat preprocess(const cv::Mat& frame);

--- a/tests/MiniFigDirectionDetectorTest.cpp
+++ b/tests/MiniFigDirectionDetectorTest.cpp
@@ -4,6 +4,8 @@
  * @author nishijima515
  */
 
+// モデルが必要なため、コメントアウト
+/*
 #include <gtest/gtest.h>
 #include "MiniFigDirectionDetector.h"
 
@@ -21,3 +23,4 @@ TEST(MiniFigDirectionDetectorTest, DetectsDirectionFromImage)
   ASSERT_TRUE(result.wasDetected);
   EXPECT_EQ(result.direction, MiniFigDirection::BACK);
 }
+*/

--- a/tests/MiniFigDirectionDetectorTest.cpp
+++ b/tests/MiniFigDirectionDetectorTest.cpp
@@ -1,0 +1,23 @@
+/**
+ * @file MiniFigDirectionDetectorTest.cpp
+ * @brief ミニフィグ向き判定クラスのテスト
+ * @author nishijima515
+ */
+
+#include <gtest/gtest.h>
+#include "MiniFigDirectionDetector.h"
+
+TEST(MiniFigDirectionDetectorTest, DetectsDirectionFromImage)
+{
+  MiniFigDirectionDetector detector("../../yolo_optimized.onnx");
+
+  // 入力画像を読み込み
+  cv::Mat img = cv::imread("../../tests/test_images/Fig1-3.jpeg");
+  ASSERT_FALSE(img.empty()) << "画像の読み込みに失敗しました";
+
+  MiniFigDirectionResult result
+      = detector.detect(img, "../../datafiles/snapshots/detected_result.jpg");
+
+  ASSERT_TRUE(result.wasDetected);
+  EXPECT_EQ(result.direction, MiniFigDirection::BACK);
+}

--- a/tests/MiniFigDirectionDetectorTest.cpp
+++ b/tests/MiniFigDirectionDetectorTest.cpp
@@ -15,15 +15,14 @@
 //   char cwd[1024];
 //   getcwd(cwd, sizeof(cwd));
 //   std::cout << "Current working directory: " << cwd << std::endl;
-//   MiniFigDirectionDetector detector("../../yolo_optimized.onnx",
-//                                     "../../datafiles/snapshots/detected_result.jpg");
+//   MiniFigDirectionDetector detector("../../yolo_optimized.onnx");
 
 //   // 入力画像を読み込み
 //   cv::Mat img = cv::imread("../../tests/test_images/Fig1-3.jpeg");
 //   ASSERT_FALSE(img.empty()) << "画像の読み込みに失敗しました";
 
 //   MiniFigDirectionResult result;
-//   detector.detect(img, /* "../../datafiles/snapshots/detected_result.jpg",*/ result);
+//   detector.detect(img, result);
 
 //   ASSERT_TRUE(result.wasDetected);
 //   EXPECT_EQ(result.direction, MiniFigDirection::BACK);

--- a/tests/MiniFigDirectionDetectorTest.cpp
+++ b/tests/MiniFigDirectionDetectorTest.cpp
@@ -5,22 +5,21 @@
  */
 
 // モデルが必要なため、コメントアウト
-/*
-#include <gtest/gtest.h>
-#include "MiniFigDirectionDetector.h"
 
-TEST(MiniFigDirectionDetectorTest, DetectsDirectionFromImage)
-{
-  MiniFigDirectionDetector detector("../../yolo_optimized.onnx");
+// #include <gtest/gtest.h>
+// #include "MiniFigDirectionDetector.h"
 
-  // 入力画像を読み込み
-  cv::Mat img = cv::imread("../../tests/test_images/Fig1-3.jpeg");
-  ASSERT_FALSE(img.empty()) << "画像の読み込みに失敗しました";
+// TEST(MiniFigDirectionDetectorTest, DetectsDirectionFromImage)
+// {
+//   MiniFigDirectionDetector detector("../../yolo_optimized.onnx");
 
-  MiniFigDirectionResult result
-      = detector.detect(img, "../../datafiles/snapshots/detected_result.jpg");
+//   // 入力画像を読み込み
+//   cv::Mat img = cv::imread("../../tests/test_images/Fig1-3.jpeg");
+//   ASSERT_FALSE(img.empty()) << "画像の読み込みに失敗しました";
 
-  ASSERT_TRUE(result.wasDetected);
-  EXPECT_EQ(result.direction, MiniFigDirection::BACK);
-}
-*/
+//   MiniFigDirectionResult result;
+//   detector.detect(img, "../../datafiles/snapshots/detected_result.jpg", result);
+
+//   ASSERT_TRUE(result.wasDetected);
+//   EXPECT_EQ(result.direction, MiniFigDirection::BACK);
+// }

--- a/tests/MiniFigDirectionDetectorTest.cpp
+++ b/tests/MiniFigDirectionDetectorTest.cpp
@@ -8,17 +8,22 @@
 
 // #include <gtest/gtest.h>
 // #include "MiniFigDirectionDetector.h"
+// #include <unistd.h>
 
 // TEST(MiniFigDirectionDetectorTest, DetectsDirectionFromImage)
 // {
-//   MiniFigDirectionDetector detector("../../yolo_optimized.onnx");
+//   char cwd[1024];
+//   getcwd(cwd, sizeof(cwd));
+//   std::cout << "Current working directory: " << cwd << std::endl;
+//   MiniFigDirectionDetector detector("../../yolo_optimized.onnx",
+//                                     "../../datafiles/snapshots/detected_result.jpg");
 
 //   // 入力画像を読み込み
 //   cv::Mat img = cv::imread("../../tests/test_images/Fig1-3.jpeg");
 //   ASSERT_FALSE(img.empty()) << "画像の読み込みに失敗しました";
 
 //   MiniFigDirectionResult result;
-//   detector.detect(img, "../../datafiles/snapshots/detected_result.jpg", result);
+//   detector.detect(img, /* "../../datafiles/snapshots/detected_result.jpg",*/ result);
 
 //   ASSERT_TRUE(result.wasDetected);
 //   EXPECT_EQ(result.direction, MiniFigDirection::BACK);


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- ミニフィグ向き判定クラスの追加
- `.gitignore`にモデルファイルを追加
- 
# 動作テスト

## 添付資料
