### PR TITLE
#KL25-89 走行体から無線通信デバイスへの画像アップロードクラスの実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
+# サーバー設定
+SERVER_URL = http://localhost
+
 # 使い方
 help:
 	@echo ビルドする
@@ -22,6 +25,8 @@ help:
 	@echo " $$ make smart-clean"
 	@echo 必要があればbuildディレクトリを削除し, テストをビルドして実行する
 	@echo " $$ make test"
+	@echo 画像をサーバーにアップロードする
+	@echo " $$ make upload-image"
 
 ## 実行関連 ##
 build:
@@ -48,8 +53,10 @@ test-exec:
 		mkdir -p etrobocon2025/datafiles/commands && \
 		mkdir -p etrobocon2025/datafiles/processed_images && \
 		cp ../../datafiles/commands/*.csv etrobocon2025/datafiles/commands && \
+		cp ../../Makefile . && \
 		./etrobocon2025_test && \
-		rm -rf etrobocon2025; \
+		rm -rf etrobocon2025 && \
+		rm -f Makefile; \
 	fi
 
 # テストをビルドして実行する
@@ -127,5 +134,7 @@ else
     }
 endif
 
-format-check:
-	find ./tests ./modules -type f -name "*.cpp" -o -name "*.h" | xargs clang-format --dry-run --Werror *.h *.cpp
+## 無線通信デバイスとの通信関連 ##
+# サーバーの画像をアップロードする
+upload-image:
+	curl -X POST -F "file=@$(FILE_PATH)" $(SERVER_URL):8000/images

--- a/modules/calculators/ImageUploader.cpp
+++ b/modules/calculators/ImageUploader.cpp
@@ -1,0 +1,52 @@
+/**
+ * @file   ImageUploader.cpp
+ * @brief  無線通信デバイスへ画像をアップロードするクラス
+ * @author Hara1274
+ */
+
+#include "ImageUploader.h"
+
+ImageUploader::ImageUploader() {}
+
+bool ImageUploader::uploadImage(const std::string& imagePath, int retries)
+{
+  // Makefile存在チェック
+  std::ifstream makefile("Makefile");
+  if(!makefile.good()) {
+    std::cerr << "Error: Makefile not found in current directory" << std::endl;
+    return false;
+  }
+
+  // 空のファイルパスのチェック
+  if(imagePath.empty()) {
+    std::cerr << "Error: Empty image path provided" << std::endl;
+    return false;
+  }
+
+  // ファイル存在チェック
+  std::ifstream file(imagePath);
+  if(!file.good()) {
+    std::cerr << "Error: File does not exist: " << imagePath << std::endl;
+    return false;
+  }
+
+  // 無効な試行回数のチェック
+  if(retries <= 0) {
+    std::cerr << "Error: Invalid retry count: " << retries << std::endl;
+    return false;
+  }
+
+  int attempts = 0;
+  while(attempts < retries) {
+    std::string command = "make upload-image FILE_PATH=" + imagePath;
+
+    int result = std::system(command.c_str());
+    if(result == 0) {
+      return true;
+    }
+    attempts++;
+  }
+
+  std::cerr << "Upload failed after " << retries << " attempts" << std::endl;
+  return false;
+}

--- a/modules/calculators/ImageUploader.h
+++ b/modules/calculators/ImageUploader.h
@@ -1,0 +1,26 @@
+/**
+ * @file   ImageUploader.h
+ * @brief  無線通信デバイスへ画像をアップロードするクラス
+ * @author Hara1274
+ */
+
+#ifndef IMAGE_UPLOADER_H_
+#define IMAGE_UPLOADER_H_
+
+#include <string>
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+
+class ImageUploader {
+ public:
+  ImageUploader();
+
+  /**
+   * @brief 画像をサーバーにアップロードする
+   * @return アップロード成功時true、失敗時false
+   */
+  bool uploadImage(const std::string& imagePath, int retries = 3);
+};
+
+#endif  // IMAGE_UPLOADER_H_

--- a/tests/ImageUploaderTest.cpp
+++ b/tests/ImageUploaderTest.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file   ImageUploaderTest.cpp
+ * @brief  ImageUploaderクラスをテストする
+ * @author Hara1274
+ */
+
+#include "ImageUploader.h"
+#include <gtest/gtest.h>
+
+namespace etrobocon2025_test {
+  // 空文字列のファイルパスで失敗することをテスト
+  TEST(ImageUploaderTest, EmptyFilePathShouldFail)
+  {
+    ImageUploader uploader;
+    bool result = uploader.uploadImage("", 1);
+    EXPECT_FALSE(result);
+  }
+
+  // ゼロ回試行で失敗することをテスト
+  TEST(ImageUploaderTest, ZeroRetriesShouldFail)
+  {
+    ImageUploader uploader;
+    bool result = uploader.uploadImage("test.jpg", 0);
+    EXPECT_FALSE(result);
+  }
+
+  // 負の試行回数で失敗することをテスト
+  TEST(ImageUploaderTest, NegativeRetriesShouldFail)
+  {
+    ImageUploader uploader;
+    bool result = uploader.uploadImage("test.jpg", -1);
+    EXPECT_FALSE(result);
+  }
+
+  // 存在しないファイルで失敗することをテスト
+  TEST(ImageUploaderTest, NonExistentFileShouldFail)
+  {
+    ImageUploader uploader;
+    bool result = uploader.uploadImage("nonexistent_file.jpg", 1);
+    EXPECT_FALSE(result);
+  }
+
+  // コンストラクタが正常に動作することをテスト
+  TEST(ImageUploaderTest, Constructor)
+  {
+    EXPECT_NO_THROW(ImageUploader uploader);
+  }
+
+  // 実在するファイルでアップロード処理が実行されることをテスト
+  TEST(ImageUploaderTest, ValidFileUpload)
+  {
+    ImageUploader uploader;
+    std::string validPath = "../../tests/test_images/test_data.JPEG";
+    // サーバーの状態に関係なく例外が発生しないことを確認
+    EXPECT_NO_THROW(uploader.uploadImage(validPath, 1));
+  }
+}  // namespace etrobocon2025_test


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
- ImageUploaderクラスを作成
- makefileに upload-image コマンドを追加


# 動作テスト

## 実験方法

## 実験データ

|  修正前  |  修正後  |
| ---- | ---- |
|  -  |  -  |
|  -  |  -  |

## 実験結果

## 添付資料
