### PR TITLE
#KL25-91 カメラライントレースの目標発見失敗時の動作実装

### DIFF
--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -188,6 +188,44 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         break;
       }
 
+      // CRA: カメラ復帰動作
+      // [1]:int 回頭角度[deg], [2]:double 回頭スピード[mm/s], [3]:string 回頭の方向(clockwise or
+      // anticlockwise), [4-9]:int HSV値(lowerH,lowerS,lowerV,upperH,upperS,upperV), [10-13]int
+      // ROI座標[px]
+      // ([10]左上隅のx座標, [11]左上隅のy座標, [12]幅, [13]高さ), [14-15]int 解像度[px] ([14]幅,
+      // [15]高さ)
+      // 補足：ROI（Region of Interest: ライントレース用の画像内注目領域（四角形））
+      case COMMAND::CRA: {
+        cv::Scalar lowerHSV, upperHSV;
+        cv::Rect roi;
+        cv::Size resolution;
+        std::unique_ptr<BoundingBoxDetector> boundingBoxDetector;
+
+        lowerHSV = cv::Scalar(stoi(params[4]), stoi(params[5]), stoi(params[6]));
+        upperHSV = cv::Scalar(stoi(params[7]), stoi(params[8]), stoi(params[9]));
+
+        // パラメータ配列のサイズによってコンストラクタを切り替え
+        if(params.size() > 15) {
+          // ROI + 解像度
+          roi = cv::Rect(stoi(params[10]), stoi(params[11]), stoi(params[12]), stoi(params[13]));
+          resolution = cv::Size(stoi(params[14]), stoi(params[15]));
+          boundingBoxDetector
+              = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV, roi, resolution);
+        } else if(params.size() > 13) {
+          // ROIのみ
+          roi = cv::Rect(stoi(params[10]), stoi(params[11]), stoi(params[12]), stoi(params[13]));
+          boundingBoxDetector = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV, roi);
+        } else {
+          // HSVのみ
+          boundingBoxDetector = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV);
+        }
+
+        auto cra = new CameraRecoveryAction(robot, stoi(params[1]), stod(params[2]),
+                                            convertBool(params[0], params[3]),
+                                            std::move(boundingBoxDetector));
+        motionList.push_back(cra);
+        break;
+      }
       // 未定義コマンド
       default: {
         cout << commandFilePath << ":" << lineNum << " Command " << params[0] << " は未定義です"
@@ -216,7 +254,8 @@ COMMAND MotionParser::convertCommand(const string& str)
     { "EC", COMMAND::EC },    // エッジ切り替え
     { "SL", COMMAND::SL },    // スリープ
     { "SS", COMMAND::SS },    // カメラ撮影動作
-    { "MCA", COMMAND::MCA }   // ミニフィグのカメラ撮影動作
+    { "MCA", COMMAND::MCA },  // ミニフィグのカメラ撮影動作
+    { "CRA", COMMAND::CRA }   // カメラ復帰動作
   };
 
   // コマンド文字列に対応するCOMMAND値をマップから取得。なければCOMMAND::NONEを返す
@@ -233,8 +272,8 @@ bool MotionParser::convertBool(const string& command, const string& stringParame
   // 末尾の改行を削除
   string param = StringOperator::removeEOL(stringParameter);
 
-  // 回転動作(AR,MCA)の場合、"clockwise"ならtrue（時計回り）、"anticlockwise"ならfalse（反時計回り）に変換
-  if(command == "AR" || command == "MCA") {
+  // 回転動作(AR,MCA,CRA)の場合、"clockwise"ならtrue（時計回り）、"anticlockwise"ならfalse（反時計回り）に変換
+  if(command == "AR" || command == "MCA" || command == "CRA") {
     if(param == "clockwise") {
       return true;
     } else if(param == "anticlockwise") {

--- a/modules/MotionParser.h
+++ b/modules/MotionParser.h
@@ -26,6 +26,7 @@
 #include "Sleeping.h"
 #include "Snapshot.h"
 #include "MiniFigCameraAction.h"
+#include "CameraRecoveryAction.h"
 
 enum class COMMAND {
   AR,   // 角度指定回頭
@@ -39,6 +40,7 @@ enum class COMMAND {
   SL,   // 自タスクスリープ
   SS,   // カメラ撮影動作
   MCA,  // ミニフィグのカメラ撮影動作
+  CRA,  // カメラ復帰動作
   NONE
 };
 

--- a/modules/motions/CameraPidTracking.cpp
+++ b/modules/motions/CameraPidTracking.cpp
@@ -28,9 +28,6 @@ void CameraPidTracking::run()
   // 事前準備
   prepare();
 
-  // 左右で符号を変える
-  int edgeSign = robot.getIsLeftEdge() ? -1 : 1;
-
   SpeedCalculator speedCalculator(robot, targetSpeed);
 
   // 継続条件を満たしている間ループ
@@ -55,7 +52,7 @@ void CameraPidTracking::run()
     double currentX = (result.topLeft.x + result.bottomRight.x) / 2.0;
 
     // 旋回値の計算
-    double turningPower = pid.calculatePid(currentX) * edgeSign;
+    double turningPower = pid.calculatePid(currentX) * (-1.0);
 
     // モータのPower値をセット（前進の時0を下回らないように，後進の時0を上回らないようにセット）
     double rightPower = baseRightPower > 0.0 ? std::max(baseRightPower - turningPower, 0.0)

--- a/modules/motions/CameraRecoveryAction.cpp
+++ b/modules/motions/CameraRecoveryAction.cpp
@@ -1,0 +1,58 @@
+/**
+ * @file   CameraRecoveryAction.cpp
+ * @brief  カメラ検出失敗時の復帰動作クラス
+ * @author HaruArima08
+ */
+
+#include "CameraRecoveryAction.h"
+
+CameraRecoveryAction::CameraRecoveryAction(
+    Robot& _robot, int _angle, double _speed, bool _isClockwise,
+    std::unique_ptr<BoundingBoxDetector> _boundingBoxDetector)
+  : Motion(_robot),
+    recoveryAngle(_angle),
+    speed(_speed),
+    isClockwise(_isClockwise),
+    boundingBoxDetector(std::move(_boundingBoxDetector))
+{
+}
+
+void CameraRecoveryAction::run()
+{
+  cv::Mat frame;
+  // 初期検出確認
+  if(!robot.getCameraCaptureInstance().getFrame(frame) || frame.empty()) {
+    recoverySuccess = false;
+    return;  // フレーム取得失敗
+  }
+
+  // 複数フレームでの検出確認
+  for(int i = 0; i < FRAME_NUMBER; i++) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(33));  // フレーム間の待機(33ミリ秒)
+    robot.getCameraCaptureInstance().getFrame(frame);
+  }
+
+  boundingBoxDetector->detect(frame, result);
+
+  // 既に検出できた場合、復帰動作を行わない
+  if(result.wasDetected) {
+    recoverySuccess = true;
+    return;
+  }
+  // 指定された角度・スピード・方向で回頭復帰
+  AngleRotation rotation(robot, recoveryAngle, speed, isClockwise);
+  rotation.run();
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));  // 10ミリ秒待機
+
+  boundingBoxDetector->detect(frame, result);
+  if(result.wasDetected) {
+    recoverySuccess = true;
+    return;  // 検出成功
+  }
+  recoverySuccess = false;  // 復帰失敗
+}
+
+bool CameraRecoveryAction::isRecoverySuccessful() const
+{
+  return recoverySuccess;
+}

--- a/modules/motions/CameraRecoveryAction.h
+++ b/modules/motions/CameraRecoveryAction.h
@@ -1,0 +1,48 @@
+/**
+ * @file   CameraRecoveryAction.h
+ * @brief  カメラ検出失敗時の復帰動作クラス
+ * @author HaruArima08
+ */
+
+#ifndef CAMERA_RECOVERY_ACTION_H
+#define CAMERA_RECOVERY_ACTION_H
+
+#include "Motion.h"
+#include "BoundingBoxDetector.h"
+#include "AngleRotation.h"
+
+class CameraRecoveryAction : public Motion {
+ public:
+  /**
+   * コンストラクタ
+   * @param _robot ロボットインスタンス
+   * @param _angle 回頭角度 (dig) 0~360
+   * @param _speed 回頭速度（mm/秒）
+   * @param _isClockwise 回頭方向（true: 右回り, false: 左回り）
+   * @param _boundingBoxDetector 画像処理クラスのポインタ
+   */
+  CameraRecoveryAction(Robot& _robot, int _angle, double _speed, bool _isClockwise,
+                       std::unique_ptr<BoundingBoxDetector> _boundingBoxDetector);
+
+  /**
+   * @brief カメラフレーム復帰動作を実行する
+   */
+  void run() override;
+
+  /**
+   * @brief 復帰動作が成功したかチェック
+   * @return true: 復帰成功, false: 復帰失敗
+   */
+  bool isRecoverySuccessful() const;
+
+ private:
+  std::unique_ptr<BoundingBoxDetector> boundingBoxDetector;  // 画像処理クラスのポインタ
+  BoundingBoxDetectionResult result;                         // 検出結果
+  int recoveryAngle;                                         // 復帰回頭角度
+  double speed;                                              // 回頭スピード
+  bool isClockwise;                                          // 回頭方向
+  static constexpr int FRAME_NUMBER = 5;                     // フレーム取得回数
+  bool recoverySuccess = false;                              // 復帰成功フラグ
+};
+
+#endif


### PR DESCRIPTION
# チェックリスト

- [ ] clang-format している
- [ ] コーディング規約に準じている
- [ ] チケットの完了条件を満たしている

# 変更点
-カメラ検出失敗時の復帰動作クラスCameraRecoveryActionの追加
-MotionParserに復帰動作(CRA)コマンドの追加

# 動作テスト
[Notionを参考](https://www.notion.so/uom-katlab/23add5b1cc1880999518cf97d18112c1?source=copy_link)
