### PR TITLE
#KL25-102 色距離指定カメラライントレース

### DIFF
--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -320,7 +320,7 @@ COMMAND MotionParser::convertCommand(const string& str)
     { "SL", COMMAND::SL },      // スリープ
     { "SS", COMMAND::SS },      // カメラ撮影動作
     { "MCA", COMMAND::MCA },    // ミニフィグのカメラ撮影動作
-    { "BCA", COMMAND::BCA }     // 風景・プラレールのカメラ撮影動作
+    { "BCA", COMMAND::BCA },    // 風景・プラレールのカメラ撮影動作
     { "CRA", COMMAND::CRA }     // カメラ復帰動作
   };
 

--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -116,6 +116,43 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         break;
       }
 
+      // CDCL: 色距離指定カメラライントレース
+      // [1]:string 色, [2]:double 距離[mm], [3]:double 速度[mm/s], [4]:int X座標[px],
+      // [5-7]:double PIDゲイン, [8-10]int lowerHSV, [11-13]int upperHSV, [14-17]int ROI座標[px]
+      // ([14]左上隅のx座標, [15]左上隅のy座標, [16]幅, [17]高さ), [18-19]int 解像度[px] ([18]幅,
+      // [19]高さ) 補足：ROI（Region of Interest:ライントレース用の画像内注目領域（四角形））
+      case COMMAND::CDCL: {
+        cv::Scalar lowerHSV, upperHSV;
+        cv::Rect roi;
+        cv::Size resolution;
+        std::unique_ptr<BoundingBoxDetector> detector;
+
+        lowerHSV = cv::Scalar(stoi(params[8]), stoi(params[9]), stoi(params[10]));
+        upperHSV = cv::Scalar(stoi(params[11]), stoi(params[12]), stoi(params[13]));
+
+        // パラメータ配列のサイズによってコンストラクタを切り替え
+        if(params.size() > 19) {
+          // ROI + 解像度
+          roi = cv::Rect(stoi(params[14]), stoi(params[15]), stoi(params[16]), stoi(params[17]));
+          resolution = cv::Size(stoi(params[18]), stoi(params[19]));
+          detector = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV, roi, resolution);
+        } else if(params.size() > 17) {
+          // ROIのみ
+          roi = cv::Rect(stoi(params[14]), stoi(params[15]), stoi(params[16]), stoi(params[17]));
+          detector = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV, roi);
+        } else {
+          // HSVのみ
+          detector = std::make_unique<LineBoundingBoxDetector>(lowerHSV, upperHSV);
+        }
+
+        auto cdcl = new ColorDistanceCameraLineTrace(
+            robot, ColorJudge::convertStringToColor(params[1]), stod(params[2]), stod(params[3]),
+            stoi(params[4]), PidGain(stod(params[5]), stod(params[6]), stod(params[7])),
+            std::move(detector));
+        motionList.push_back(cdcl);
+        break;
+      }
+
       // CL: 指定色ライントレース
       // [1]:string 色, [2]:double 速度[mm/s], [3]:int 輝度補正, [4-6]:double PIDゲイン
       case COMMAND::CL: {
@@ -232,18 +269,19 @@ COMMAND MotionParser::convertCommand(const string& str)
 {
   // コマンド文字列(string)と、それに対応する列挙型COMMANDのマッピングを定義
   static const unordered_map<string, COMMAND> commandMap = {
-    { "AR", COMMAND::AR },    // 角度指定回頭
-    { "DS", COMMAND::DS },    // 指定距離直進
-    { "CS", COMMAND::CS },    // 指定色直進
-    { "DL", COMMAND::DL },    // 指定距離ライントレース
-    { "DCL", COMMAND::DCL },  // 指定距離カメラライントレース
-    { "CL", COMMAND::CL },    // 指定色ライントレース
-    { "CDL", COMMAND::CDL },  // 色距離指定ライントレース
-    { "EC", COMMAND::EC },    // エッジ切り替え
-    { "SL", COMMAND::SL },    // スリープ
-    { "SS", COMMAND::SS },    // カメラ撮影動作
-    { "MCA", COMMAND::MCA },  // ミニフィグのカメラ撮影動作
-    { "BCA", COMMAND::BCA }   // 風景・プラレールのカメラ撮影動作
+    { "AR", COMMAND::AR },      // 角度指定回頭
+    { "DS", COMMAND::DS },      // 指定距離直進
+    { "CS", COMMAND::CS },      // 指定色直進
+    { "DL", COMMAND::DL },      // 指定距離ライントレース
+    { "DCL", COMMAND::DCL },    // 指定距離カメラライントレース
+    { "CDCL", COMMAND::CDCL },  // 色距離指定カメラライントレース
+    { "CL", COMMAND::CL },      // 指定色ライントレース
+    { "CDL", COMMAND::CDL },    // 色距離指定ライントレース
+    { "EC", COMMAND::EC },      // エッジ切り替え
+    { "SL", COMMAND::SL },      // スリープ
+    { "SS", COMMAND::SS },      // カメラ撮影動作
+    { "MCA", COMMAND::MCA },    // ミニフィグのカメラ撮影動作
+    { "BCA", COMMAND::BCA }     // 風景・プラレールのカメラ撮影動作
 
   };
 

--- a/modules/MotionParser.h
+++ b/modules/MotionParser.h
@@ -28,6 +28,7 @@
 #include "MiniFigCameraAction.h"
 #include "BackgroundPlaCameraAction.h"
 #include "ColorDistanceCameraLineTrace.h"
+#include "CameraRecoveryAction.h"
 
 enum class COMMAND {
   AR,    // 角度指定回頭

--- a/modules/MotionParser.h
+++ b/modules/MotionParser.h
@@ -27,20 +27,22 @@
 #include "Snapshot.h"
 #include "MiniFigCameraAction.h"
 #include "BackgroundPlaCameraAction.h"
+#include "ColorDistanceCameraLineTrace.h"
 
 enum class COMMAND {
-  AR,   // 角度指定回頭
-  DS,   // 指定距離直進
-  CS,   // 指定色直進
-  DL,   // 指定距離ライントレース
-  DCL,  // 指定距離カメラライントレース
-  CL,   // 指定色ライントレース
-  CDL,  // 色距離指定ライントレース
-  EC,   // エッジ切り替え
-  SL,   // 自タスクスリープ
-  SS,   // カメラ撮影動作
-  MCA,  // ミニフィグのカメラ撮影動作
-  BCA,  // 背景のカメラ撮影動作
+  AR,    // 角度指定回頭
+  DS,    // 指定距離直進
+  CS,    // 指定色直進
+  DL,    // 指定距離ライントレース
+  DCL,   // 指定距離カメラライントレース
+  CDCL,  // 色距離指定カメラライントレース
+  CL,    // 指定色ライントレース
+  CDL,   // 色距離指定ライントレース
+  EC,    // エッジ切り替え
+  SL,    // 自タスクスリープ
+  SS,    // カメラ撮影動作
+  MCA,   // ミニフィグのカメラ撮影動作
+  BCA,   // 背景のカメラ撮影動作
   NONE
 };
 

--- a/modules/motions/ColorDistanceCameraLineTrace.cpp
+++ b/modules/motions/ColorDistanceCameraLineTrace.cpp
@@ -1,0 +1,75 @@
+/**
+ * @file   ColorDistanceCameraLineTrace.cpp
+ * @brief  色距離指定カメラライントレース動作
+ * @author HaruArima08 nishijima515
+ */
+
+#include "ColorDistanceCameraLineTrace.h"
+
+ColorDistanceCameraLineTrace::ColorDistanceCameraLineTrace(
+    Robot& _robot, COLOR _targetColor, double _targetDistance, double _targetSpeed,
+    int _targetXCoordinate, const PidGain& _pidGain, std::unique_ptr<BoundingBoxDetector> _detector)
+  : CameraPidTracking(_robot, _targetSpeed, _targetXCoordinate, _pidGain, *_detector),
+    targetColor(_targetColor),
+    colorCount(0),
+    targetDistance(_targetDistance),
+    detector(std::move(_detector))
+{
+}
+
+// 色距離指定カメラライントレースの事前条件
+bool ColorDistanceCameraLineTrace::isMetPreCondition()
+{
+  // 目標の色がNoneのとき終了する
+  if(targetColor == COLOR::NONE) {
+    return false;
+  }
+
+  // targetSpeed値が0の場合は終了する
+  if(targetSpeed == 0.0) {
+    return false;
+  }
+
+  // targetDistance値が0以下の場合は終了する
+  if(targetDistance <= 0.0) {
+    return false;
+  }
+
+  return true;
+}
+
+// 色距離指定カメラライントレースの事前処理
+void ColorDistanceCameraLineTrace::prepare()
+{
+  // 初期値を代入
+  initDistance = Mileage::calculateMileage(robot.getMotorControllerInstance().getRightMotorCount(),
+                                           robot.getMotorControllerInstance().getLeftMotorCount());
+
+  // 色カウントを初期化
+  colorCount = 0;
+}
+
+// 色距離指定カメラライントレースの継続条件
+bool ColorDistanceCameraLineTrace::isMetContinuationCondition()
+{
+  // HSV値を取得
+  spikeapi::ColorSensor::HSV hsv;
+  robot.getColorSensorInstance().getColor(hsv);
+
+  // 現在の色が目標色と一致していればカウント増加、違えばリセット
+  if(ColorJudge::convertHsvToColor(hsv) == targetColor) {
+    colorCount++;
+  } else {
+    colorCount = 0;
+  }
+
+  // (走行距離が目標距離に到達)||(指定された色をJUDGE_COUNT回連続で取得したとき)モータが止まる
+  if((fabs(Mileage::calculateMileage(robot.getMotorControllerInstance().getRightMotorCount(),
+                                     robot.getMotorControllerInstance().getLeftMotorCount())
+           - initDistance)
+      >= targetDistance)
+     || (colorCount >= JUDGE_COUNT))
+    return false;
+
+  return true;
+}

--- a/modules/motions/ColorDistanceCameraLineTrace.cpp
+++ b/modules/motions/ColorDistanceCameraLineTrace.cpp
@@ -44,9 +44,6 @@ void ColorDistanceCameraLineTrace::prepare()
   // 初期値を代入
   initDistance = Mileage::calculateMileage(robot.getMotorControllerInstance().getRightMotorCount(),
                                            robot.getMotorControllerInstance().getLeftMotorCount());
-
-  // 色カウントを初期化
-  colorCount = 0;
 }
 
 // 色距離指定カメラライントレースの継続条件
@@ -63,13 +60,21 @@ bool ColorDistanceCameraLineTrace::isMetContinuationCondition()
     colorCount = 0;
   }
 
-  // (走行距離が目標距離に到達)||(指定された色をJUDGE_COUNT回連続で取得したとき)モータが止まる
-  if((fabs(Mileage::calculateMileage(robot.getMotorControllerInstance().getRightMotorCount(),
-                                     robot.getMotorControllerInstance().getLeftMotorCount())
-           - initDistance)
-      >= targetDistance)
-     || (colorCount >= JUDGE_COUNT))
+  // 走行距離を計算
+  double diffDistance
+      = fabs(Mileage::calculateMileage(robot.getMotorControllerInstance().getRightMotorCount(),
+                                       robot.getMotorControllerInstance().getLeftMotorCount())
+             - initDistance);
+
+  // 走行距離が目標距離に到達したときモータが止まる
+  if(diffDistance >= targetDistance) {
     return false;
+  }
+
+  // 目標色をJUDGE_COUNT回連続で取得したときモータが止まる
+  if(colorCount >= JUDGE_COUNT) {
+    return false;
+  }
 
   return true;
 }

--- a/modules/motions/ColorDistanceCameraLineTrace.h
+++ b/modules/motions/ColorDistanceCameraLineTrace.h
@@ -14,6 +14,7 @@ class ColorDistanceCameraLineTrace : public CameraPidTracking {
  public:
   /**
    * コンストラクタ
+   * @param _robot ロボットインスタンス
    * @param _targetColor 指定色
    * @param _targetDistance 目標距離
    * @param _targetSpeed 目標速度
@@ -50,7 +51,7 @@ class ColorDistanceCameraLineTrace : public CameraPidTracking {
 
  private:
   static constexpr int JUDGE_COUNT = 2;           // 色取得の決定に必要な連続回数
-  int colorCount;                                 // 色取得した回数
+  int colorCount;                                 // 指定色を取得した回数
   COLOR targetColor;                              // 指定色
   double targetDistance;                          // 目標距離
   double initDistance;                            // 実行前の走行距離

--- a/modules/motions/ColorDistanceCameraLineTrace.h
+++ b/modules/motions/ColorDistanceCameraLineTrace.h
@@ -1,0 +1,60 @@
+/**
+ * @file   ColorDistanceCameraLineTrace.h
+ * @brief  色距離指定カメラライントレース動作
+ * @author HaruArima08 nishijima515
+ */
+
+#ifndef COLOR_DISTANCE_CAMERA_LINE_TRACE_H
+#define COLOR_DISTANCE_CAMERA_LINE_TRACE_H
+
+#include "CameraPidTracking.h"
+#include "ColorJudge.h"
+
+class ColorDistanceCameraLineTrace : public CameraPidTracking {
+ public:
+  /**
+   * コンストラクタ
+   * @param _targetColor 指定色
+   * @param _targetDistance 目標距離
+   * @param _targetSpeed 目標速度
+   * @param _targetXCoordinate 目標x座標
+   * @param _pidGain PIDゲイン
+   * @param _detector 画像処理クラスのポインタ
+   */
+  ColorDistanceCameraLineTrace(Robot& _robot, COLOR _targetColor, double _targetDistance,
+                               double _targetSpeed, int _targetXCoordinate, const PidGain& _pidGain,
+                               std::unique_ptr<BoundingBoxDetector> _detector);
+
+  /**
+   * @brief (指定距離まで||指定色認識する)だけカメラライントレースする
+   */
+  using CameraPidTracking::run;
+
+ protected:
+  /**
+   * @brief 色距離指定カメラライントレースする際の事前条件判定をする
+   */
+
+  bool isMetPreCondition() override;
+
+  /**
+   * @brief ライントレースする際の事前処理をする
+   */
+  void prepare() override;
+
+  /**
+   * @brief
+   * 色距離指定カメラライントレースする際の継続条件判定をする。
+   */
+  bool isMetContinuationCondition() override;
+
+ private:
+  static constexpr int JUDGE_COUNT = 2;           // 色取得の決定に必要な連続回数
+  int colorCount;                                 // 色取得した回数
+  COLOR targetColor;                              // 指定色
+  double targetDistance;                          // 目標距離
+  double initDistance;                            // 実行前の走行距離
+  std::unique_ptr<BoundingBoxDetector> detector;  // 画像処理クラスのポインタ
+};
+
+#endif

--- a/tests/ColorDistanceCameraLineTraceTest.cpp
+++ b/tests/ColorDistanceCameraLineTraceTest.cpp
@@ -1,0 +1,226 @@
+/**
+ * @file   ColorDistanceCameraLineTraceTest.cpp
+ * @brief  ColorDistanceCameraLineTraceクラスのテスト
+ * @author HaruArima08 nishijima515
+ */
+
+#include "ColorDistanceCameraLineTrace.h"
+#include "DummyBoundingBoxDetector.h"
+#include "DummyCameraCapture.h"
+#include <gtest/gtest.h>
+
+#define ERROR 1.01  // 許容誤差の倍率
+
+using namespace std;
+
+namespace etrobocon2025_test {
+
+  // 走行直後に3回の色取得で連続して指定色を取得し、かつ目標距離に到達しない時のテストケース
+  TEST(ColorDistanceCameraLineTraceTest, RunToGetColorImmediate)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    COLOR targetColor = COLOR::BLUE;
+    double targetDistance = 1000.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 400;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    auto detector = make_unique<DummyBoundingBoxDetector>();
+
+    ColorDistanceCameraLineTrace cdcl(robot, targetColor, targetDistance, targetSpeed, targetPoint,
+                                      gain, move(detector));
+
+    double expected = 0.0;  // 走行していない時の走行距離
+
+    srand(9037);  // 3回連続して青を取得する乱数シード
+
+    cdcl.run();  // 青までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LT(expected, actual);        // 走行距離が初期値より少し進んでいる
+    EXPECT_LT(actual, targetDistance);  // 目標距離未満で停止している
+  }
+
+  // 少し走行後、指定色を取得し、かつ目標距離に到達しない時のテストケース
+  TEST(ColorDistanceCameraLineTraceTest, RunToGetColorDelayed)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    COLOR targetColor = COLOR::BLUE;
+    double targetDistance = 1000.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 400;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    auto detector = make_unique<DummyBoundingBoxDetector>();
+
+    ColorDistanceCameraLineTrace cdcl(robot, targetColor, targetDistance, targetSpeed, targetPoint,
+                                      gain, move(detector));
+
+    double expected = 0.0;  // 走行していない時の走行距離
+
+    srand(0);  // 最初に識別する色が青ではない乱数シード
+
+    cdcl.run();  // 青までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LT(expected, actual);        // 走行距離が初期値より少し進んでいる
+    EXPECT_LT(actual, targetDistance);  // 目標距離までに停止している
+  }
+
+  // 負のtargetSpeed値で走行しつつ指定色を取得し、かつ目標距離に到達しない時のテストケース
+  TEST(ColorDistanceCameraLineTraceTest, RunBackToGetColor)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    COLOR targetColor = COLOR::BLUE;
+    double targetDistance = 1000.0;
+    double targetSpeed = -500.0;
+    int targetPoint = 400;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    auto detector = make_unique<DummyBoundingBoxDetector>();
+
+    ColorDistanceCameraLineTrace cdcl(robot, targetColor, targetDistance, targetSpeed, targetPoint,
+                                      gain, move(detector));
+
+    double expected = 0.0;  // 走行していない時の走行距離
+
+    srand(0);  // 最初に識別する色が青ではない乱数シード
+
+    cdcl.run();  // 青までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_LT(actual, expected);        // 初期値より後退している
+    EXPECT_LT(actual, targetDistance);  // 目標距離までに停止している
+  }
+
+  // 目標距離までライントレースを行い、かつ指定色を取得できていない時のテストケース
+  TEST(ColorDistanceCameraLineTraceTest, DistanceRunNoGetColor)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    COLOR targetColor = COLOR::BLUE;
+    double targetDistance = 100.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 400;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    auto detector = make_unique<DummyBoundingBoxDetector>();
+
+    ColorDistanceCameraLineTrace cdcl(robot, targetColor, targetDistance, targetSpeed, targetPoint,
+                                      gain, move(detector));
+
+    double expected = targetDistance;
+
+    srand(1500);  // BLUE が出にくいシード値
+
+    cdcl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_GT(expected * ERROR, actual);  // ライントレース後に走行した距離が許容誤差未満である
+  }
+
+  // targetSpeed値が0の時に終了するテストケース
+  TEST(ColorDistanceCameraLineTraceTest, RunZeroSpeed)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    COLOR targetColor = COLOR::BLUE;
+    double targetDistance = 1000.0;
+    double targetSpeed = 0.0;
+    int targetPoint = 400;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    auto detector = make_unique<DummyBoundingBoxDetector>();
+
+    ColorDistanceCameraLineTrace cdcl(robot, targetColor, targetDistance, targetSpeed, targetPoint,
+                                      gain, move(detector));
+    double expected = 0.0;
+
+    srand(0);  // 最初に識別する色が青ではない乱数シード
+
+    cdcl.run();  // 青までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expected, actual);  // 正確に終了している
+  }
+
+  // 目標の色がNONEの時に終了するテストケース
+  TEST(ColorDistanceCameraLineTraceTest, RunNoneColor)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    COLOR targetColor = COLOR::NONE;
+    double targetDistance = 1000.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 400;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    auto detector = make_unique<DummyBoundingBoxDetector>();
+
+    ColorDistanceCameraLineTrace cdcl(robot, targetColor, targetDistance, targetSpeed, targetPoint,
+                                      gain, move(detector));
+
+    double expected = 0.0;
+
+    cdcl.run();  // ライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expected, actual);  // 正確に終了している
+  }
+
+  // targetDistance値が0以下の時に終了するテストケース
+  TEST(ColorDistanceCameraLineTraceTest, RunMinusDistance)
+  {
+    DummyCameraCapture cameraCapture;
+    Robot robot(cameraCapture);
+    COLOR targetColor = COLOR::BLUE;
+    double targetDistance = 0.0;
+    double targetSpeed = 500.0;
+    int targetPoint = 400;
+    PidGain gain = { 0.1, 0.05, 0.05 };
+
+    auto detector = make_unique<DummyBoundingBoxDetector>();
+
+    ColorDistanceCameraLineTrace cdcl(robot, targetColor, targetDistance, targetSpeed, targetPoint,
+                                      gain, move(detector));
+    double expected = 0.0;
+
+    srand(0);  // 最初に識別する色が青ではない乱数シード
+
+    cdcl.run();  // 青までライントレースを実行
+
+    // ライントレース後の走行距離
+    int rightCount = robot.getMotorControllerInstance().getRightMotorCount();
+    int leftCount = robot.getMotorControllerInstance().getLeftMotorCount();
+    double actual = Mileage::calculateMileage(rightCount, leftCount);
+
+    EXPECT_EQ(expected, actual);  // 正確に終了している
+  }
+}  // namespace etrobocon2025_test

--- a/tests/ColorDistanceCameraLineTraceTest.cpp
+++ b/tests/ColorDistanceCameraLineTraceTest.cpp
@@ -15,7 +15,7 @@ using namespace std;
 
 namespace etrobocon2025_test {
 
-  // 走行直後に3回の色取得で連続して指定色を取得し、かつ目標距離に到達しない時のテストケース
+  // 走行直後に指定色を3回連続取得し、かつ目標距離に到達しない場合、走行距離が初期値より少し進み、目標距離未満で停止することを確認するテストケース
   TEST(ColorDistanceCameraLineTraceTest, RunToGetColorImmediate)
   {
     DummyCameraCapture cameraCapture;
@@ -46,7 +46,7 @@ namespace etrobocon2025_test {
     EXPECT_LT(actual, targetDistance);  // 目標距離未満で停止している
   }
 
-  // 少し走行後、指定色を取得し、かつ目標距離に到達しない時のテストケース
+  // 少し走行後に指定色を取得し、かつ目標距離に到達しない場合、走行距離が初期値より進み、目標距離未満で停止することを確認するテストケース
   TEST(ColorDistanceCameraLineTraceTest, RunToGetColorDelayed)
   {
     DummyCameraCapture cameraCapture;
@@ -77,7 +77,7 @@ namespace etrobocon2025_test {
     EXPECT_LT(actual, targetDistance);  // 目標距離までに停止している
   }
 
-  // 負のtargetSpeed値で走行しつつ指定色を取得し、かつ目標距離に到達しない時のテストケース
+  // 負のtargetSpeed値で走行しつつ指定色を取得し、かつ目標距離に到達しない場合、初期値より後退し、目標距離未満で停止することを確認するテストケース
   TEST(ColorDistanceCameraLineTraceTest, RunBackToGetColor)
   {
     DummyCameraCapture cameraCapture;
@@ -108,7 +108,7 @@ namespace etrobocon2025_test {
     EXPECT_LT(actual, targetDistance);  // 目標距離までに停止している
   }
 
-  // 目標距離までライントレースを行い、かつ指定色を取得できていない時のテストケース
+  // 指定色を取得できないまま目標距離に到達した場合、実際の走行距離が目標距離の許容誤差以内であることを確認するテストケース
   TEST(ColorDistanceCameraLineTraceTest, DistanceRunNoGetColor)
   {
     DummyCameraCapture cameraCapture;
@@ -138,7 +138,7 @@ namespace etrobocon2025_test {
     EXPECT_GT(expected * ERROR, actual);  // ライントレース後に走行した距離が許容誤差未満である
   }
 
-  // targetSpeed値が0の時に終了するテストケース
+  // targetSpeed値が0の場合、停止することを確認するテストケース
   TEST(ColorDistanceCameraLineTraceTest, RunZeroSpeed)
   {
     DummyCameraCapture cameraCapture;
@@ -167,7 +167,7 @@ namespace etrobocon2025_test {
     EXPECT_EQ(expected, actual);  // 正確に終了している
   }
 
-  // 目標の色がNONEの時に終了するテストケース
+  // 指定色がNONEの場合、停止することを確認するテストケース
   TEST(ColorDistanceCameraLineTraceTest, RunNoneColor)
   {
     DummyCameraCapture cameraCapture;
@@ -195,7 +195,7 @@ namespace etrobocon2025_test {
     EXPECT_EQ(expected, actual);  // 正確に終了している
   }
 
-  // targetDistance値が0以下の時に終了するテストケース
+  // targetDistance値が0以下の場合、停止することを確認するテストケース
   TEST(ColorDistanceCameraLineTraceTest, RunMinusDistance)
   {
     DummyCameraCapture cameraCapture;


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
-色距離指定カメラライントレースの実装
-MotionParserにコマンド追加
-色距離指定カメラライントレースのテスト追加

# 動作テスト
[Notionを参考](https://www.notion.so/uom-katlab/248dd5b1cc1880038abad756f4227e5c?source=copy_link)