### PR TITLE
#KL25-116 ダブルループ調整

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ datafiles/processed_images
 datafiles/models
 datafiles/figures
 datafiles/detection_target
+datafiles/plarail
 tests/test_images
 third_party
 yolo_detection_system/result

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # サーバーのIPアドレス
-SERVER_IP = IPアドレス
+SERVER_IP = 172.20.1.219
 
 # 使い方
 help:
@@ -142,3 +142,7 @@ format-check:
 # サーバーの画像をアップロードする
 upload-image:
 	curl --fail -X POST -F "file=@$(FILE_PATH)" http://$(SERVER_IP):8000/images
+
+# ミニフィグ画像をサーバーにアップロードする
+upload-minifig-image:
+	curl --fail -X POST -F "file=@$(FILE_PATH)" http://$(SERVER_IP):8000/minifig/detect

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # サーバーのIPアドレス
-SERVER_IP = 172.20.1.219
+SERVER_IP = IPアドレス
 
 # 使い方
 help:
@@ -143,6 +143,6 @@ format-check:
 upload-image:
 	curl --fail -X POST -F "file=@$(FILE_PATH)" http://$(SERVER_IP):8000/images
 
-# ミニフィグ画像をサーバーにアップロードする
+# ミニフィグの正面らしさ比較用画像をサーバーにアップロードする
 upload-minifig-image:
 	curl --fail -X POST -F "file=@$(FILE_PATH)" http://$(SERVER_IP):8000/minifig/detect

--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -247,7 +247,7 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         // MCA: ミニフィグのカメラ撮影動作
         // [1]:int フロントカメラをミニフィグに向けるための回頭角度[deg],
         // [2]:int 黒線復帰のための回頭角度[deg],
-        // [3]:double 撮影前後の回頭のための目標速度[mm/s],
+        // [3]:int 撮影前後の回頭のための基準パワー値,
         // [4]:double 撮影前の後退距離[mm],
         // [5]:double 撮影後の前進距離[mm],
         // [6]:double 撮影前の後退速度の絶対値[mm/s],
@@ -256,7 +256,7 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         // [9]:int 撮影位置(0が初期位置)
       case COMMAND::MCA: {
         auto mca = new MiniFigCameraAction(robot, convertBool(params[0], params[8]),
-                                           stoi(params[1]), stoi(params[2]), stod(params[3]),
+                                           stoi(params[1]), stoi(params[2]), stoi(params[3]),
                                            stod(params[4]), stod(params[5]), stod(params[6]),
                                            stod(params[7]), stoi(params[9]));
         motionList.push_back(mca);
@@ -268,7 +268,7 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         // [1]:bool isClockwise（"clockwise"/"anticlockwise"）
         // [2]:int preTargetAngle
         // [3]:int postTargetAngle
-        // [4]:double 回頭速度
+        // [4]:int 回頭基準パワー値
         // [5]:double threshold（動体検出用）
         // [6]:double minArea（動体矩形とみなす最小面積）
         // [7]:int ROIの左上X座標
@@ -284,7 +284,7 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         roi = cv::Rect(stoi(params[7]), stoi(params[8]), stoi(params[9]), stoi(params[10]));
 
         auto bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]),
-                                                 stoi(params[3]), stod(params[4]), stod(params[5]),
+                                                 stoi(params[3]), stoi(params[4]), stod(params[5]),
                                                  stod(params[6]), roi, stoi(params[11]));
 
         motionList.push_back(bca);

--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -254,11 +254,25 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         // [7]:double 撮影後の前進速度の絶対値[mm/s],
         // [8]:string 回頭の方向(clockwise or anticlockwise),
         // [9]:int 撮影位置(0が初期位置)
+        // [10]:double kp（回頭PIDのP値）[オプション]
+        // [11]:double ki（回頭PIDのI値）[オプション]
+        // [12]:double kd（回頭PIDのD値）[オプション]
       case COMMAND::MCA: {
-        auto mca = new MiniFigCameraAction(robot, convertBool(params[0], params[8]),
-                                           stoi(params[1]), stoi(params[2]), stoi(params[3]),
-                                           stod(params[4]), stod(params[5]), stod(params[6]),
-                                           stod(params[7]), stoi(params[9]));
+        MiniFigCameraAction* mca;
+        if (params.size() >= 13) {
+          // PID値が指定されている場合
+          mca = new MiniFigCameraAction(robot, convertBool(params[0], params[8]),
+                                        stoi(params[1]), stoi(params[2]), stoi(params[3]),
+                                        stod(params[4]), stod(params[5]), stod(params[6]),
+                                        stod(params[7]), stoi(params[9]),
+                                        stod(params[10]), stod(params[11]), stod(params[12]));
+        } else {
+          // PID値が指定されていない場合、デフォルト値を使用
+          mca = new MiniFigCameraAction(robot, convertBool(params[0], params[8]),
+                                        stoi(params[1]), stoi(params[2]), stoi(params[3]),
+                                        stod(params[4]), stod(params[5]), stod(params[6]),
+                                        stod(params[7]), stoi(params[9]));
+        }
         motionList.push_back(mca);
 
         break;
@@ -276,6 +290,9 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         // [9]:int ROIの幅
         // [10]:int ROIの高さ
         // [11]:int position（0=初期位置）
+        // [12]:double kp（回頭PIDのP値）[オプション]
+        // [13]:double ki（回頭PIDのI値）[オプション]
+        // [14]:double kd（回頭PIDのD値）[オプション]
 
       case COMMAND::BCA: {
         cv::Rect roi;
@@ -283,9 +300,19 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         bool isClockwise = convertBool("BCA", params[1]);
         roi = cv::Rect(stoi(params[7]), stoi(params[8]), stoi(params[9]), stoi(params[10]));
 
-        auto bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]),
-                                                 stoi(params[3]), stoi(params[4]), stod(params[5]),
-                                                 stod(params[6]), roi, stoi(params[11]));
+        BackgroundPlaCameraAction* bca;
+        if (params.size() >= 15) {
+          // PID値が指定されている場合
+          bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]),
+                                              stoi(params[3]), stoi(params[4]), stod(params[5]),
+                                              stod(params[6]), roi, stoi(params[11]),
+                                              stod(params[12]), stod(params[13]), stod(params[14]));
+        } else {
+          // PID値が指定されていない場合、デフォルト値を使用
+          bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]),
+                                              stoi(params[3]), stoi(params[4]), stod(params[5]),
+                                              stod(params[6]), roi, stoi(params[11]));
+        }
 
         motionList.push_back(bca);
         break;

--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -259,19 +259,18 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         // [12]:double kd（回頭PIDのD値）[オプション]
       case COMMAND::MCA: {
         MiniFigCameraAction* mca;
-        if (params.size() >= 13) {
+        if(params.size() >= 13) {
           // PID値が指定されている場合
-          mca = new MiniFigCameraAction(robot, convertBool(params[0], params[8]),
-                                        stoi(params[1]), stoi(params[2]), stoi(params[3]),
-                                        stod(params[4]), stod(params[5]), stod(params[6]),
-                                        stod(params[7]), stoi(params[9]),
-                                        stod(params[10]), stod(params[11]), stod(params[12]));
+          mca = new MiniFigCameraAction(
+              robot, convertBool(params[0], params[8]), stoi(params[1]), stoi(params[2]),
+              stoi(params[3]), stod(params[4]), stod(params[5]), stod(params[6]), stod(params[7]),
+              stoi(params[9]), stod(params[10]), stod(params[11]), stod(params[12]));
         } else {
           // PID値が指定されていない場合、デフォルト値を使用
-          mca = new MiniFigCameraAction(robot, convertBool(params[0], params[8]),
-                                        stoi(params[1]), stoi(params[2]), stoi(params[3]),
-                                        stod(params[4]), stod(params[5]), stod(params[6]),
-                                        stod(params[7]), stoi(params[9]));
+          mca = new MiniFigCameraAction(robot, convertBool(params[0], params[8]), stoi(params[1]),
+                                        stoi(params[2]), stoi(params[3]), stod(params[4]),
+                                        stod(params[5]), stod(params[6]), stod(params[7]),
+                                        stoi(params[9]));
         }
         motionList.push_back(mca);
 
@@ -301,17 +300,17 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         roi = cv::Rect(stoi(params[7]), stoi(params[8]), stoi(params[9]), stoi(params[10]));
 
         BackgroundPlaCameraAction* bca;
-        if (params.size() >= 15) {
+        if(params.size() >= 15) {
           // PID値が指定されている場合
-          bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]),
-                                              stoi(params[3]), stoi(params[4]), stod(params[5]),
-                                              stod(params[6]), roi, stoi(params[11]),
-                                              stod(params[12]), stod(params[13]), stod(params[14]));
+          bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]), stoi(params[3]),
+                                              stoi(params[4]), stod(params[5]), stod(params[6]),
+                                              roi, stoi(params[11]), stod(params[12]),
+                                              stod(params[13]), stod(params[14]));
         } else {
           // PID値が指定されていない場合、デフォルト値を使用
-          bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]),
-                                              stoi(params[3]), stoi(params[4]), stod(params[5]),
-                                              stod(params[6]), roi, stoi(params[11]));
+          bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]), stoi(params[3]),
+                                              stoi(params[4]), stod(params[5]), stod(params[6]),
+                                              roi, stoi(params[11]));
         }
 
         motionList.push_back(bca);

--- a/modules/common/SystemInfo.h
+++ b/modules/common/SystemInfo.h
@@ -15,10 +15,12 @@ static constexpr double TREAD = 112.0;  // 走行体のトレッド幅（両輪�
 
 static constexpr double WHEEL_RADIUS = 28.0;  // 車輪の半径[mm]
 
-static constexpr int RESOLUTION_WIDTH = 800;   // 解像度の幅（規定値）[px]
-static constexpr int RESOLUTION_HEIGHT = 600;  // 解像度の高さ（規定値）[px]
-static constexpr int MIN_WIDTH = 320;          // 解像度の幅（最小値）[px]
-static constexpr int MIN_HEIGHT = 240;         // 解像度の高さ（最小値）[px]
-static constexpr int MAX_WIDTH = 1920;         // 解像度の幅（最大値）[px]
-static constexpr int MAX_HEIGHT = 1080;        // 解像度の高さ（最大値）[px]
+static constexpr int RESOLUTION_WIDTH = 800;            // 解像度の幅（規定値）[px]
+static constexpr int RESOLUTION_HEIGHT = 600;           // 解像度の高さ（規定値）[px]
+static constexpr int MIN_WIDTH = 320;                   // 解像度の幅（最小値）[px]
+static constexpr int MIN_HEIGHT = 240;                  // 解像度の高さ（最小値）[px]
+static constexpr int MAX_WIDTH = 1920;                  // 解像度の幅（最大値）[px]
+static constexpr int MAX_HEIGHT = 1080;                 // 解像度の高さ（最大値）[px]
+static constexpr const char* JPEG_EXTENSION = ".JPEG";  // 画像ファイル拡張子
+
 #endif

--- a/modules/motions/BackgroundPlaCameraAction.cpp
+++ b/modules/motions/BackgroundPlaCameraAction.cpp
@@ -28,14 +28,25 @@ BackgroundPlaCameraAction::BackgroundPlaCameraAction(Robot& _robot, bool _isCloc
 
 bool BackgroundPlaCameraAction::isMetPreCondition()
 {
-  if(position != 0 && robot.getBackgroundDirectionResult().wasDetected
-     && robot.getBackgroundDirectionResult().direction
-            != static_cast<BackgroundDirection>(position)) {
-    cout << "正面の撮影位置ではないため風景の撮影動作は行わない。" << endl;
-    return false;
-  } else {
+  // 初回（position=0）は常に動作する
+  if(position == 0) {
     return true;
   }
+
+  // 初回で判定失敗した場合は動作しない
+  if(!robot.getBackgroundDirectionResult().wasDetected) {
+    cout << "初回で判定を失敗したため、風景の撮影動作は行わない。" << endl;
+    return false;
+  }
+
+  // 判定成功したが、現在位置が正面位置ではない場合は動作しない
+  if(robot.getBackgroundDirectionResult().direction != static_cast<BackgroundDirection>(position)) {
+    cout << "現在位置が正面位置ではないため、風景の撮影動作は行わない。" << endl;
+    return false;
+  }
+
+  // 判定成功し、現在位置が正面位置の場合は動作する
+  return true;
 }
 
 // 判定動作を行う関数
@@ -165,10 +176,14 @@ void BackgroundPlaCameraAction::run()
         ImageUploader::uploadImage(filePath, fileName, 3);
       }).detach();
     } else if(!robot.getBackgroundDirectionResult().wasDetected) {
-      // 検出結果が未検出の場合は、PlaCameraActionを実行
+      // 判定失敗時用のエンドポイントに１枚目をアップロード
       cout << "風景向き判定用写真の撮影" << endl;
-      plaCameraAction.setImageSaveName("bestframe_" + to_string(position));
+      string positionImageName = "bestframe_" + to_string(position);
+      plaCameraAction.setImageSaveName(positionImageName);
       plaCameraAction.run();
+      thread([filePath = std::string(plaCameraAction.getFilePath()), positionImageName] {
+        ImageUploader::uploadImage(filePath, positionImageName, 3);
+      }).detach();
     }
 
   } else if(robot.getBackgroundDirectionResult().wasDetected) {
@@ -180,20 +195,6 @@ void BackgroundPlaCameraAction::run()
             fileName = plaCameraAction.getImageSaveName()] {
       ImageUploader::uploadImage(filePath, fileName, 3);
     }).detach();
-  } else {
-    // 一回目検出falseなら、残り、3回の撮影は確定する。
-    // 一回目の撮影で風景が検出されていない場合は、残り3つのすべてのpositionで撮影を行い、画像をpositionごとに保存する。
-    cout << "風景向き判定用写真の撮影" << endl;
-    string positionImageName = "bestframe_" + to_string(position);
-    plaCameraAction.setImageSaveName(positionImageName);
-    plaCameraAction.run();
-    // 最後のポジションの撮影時のみ非同期で画像をアップロード
-    if(position == 3) {
-      thread([filePath = std::string(plaCameraAction.getFilePath()),
-              fileName = plaCameraAction.getImageSaveName()] {
-        ImageUploader::uploadImage(filePath, fileName, 3);
-      }).detach();
-    }
   }
 
   // 動作安定のためのスリープ

--- a/modules/motions/BackgroundPlaCameraAction.cpp
+++ b/modules/motions/BackgroundPlaCameraAction.cpp
@@ -33,9 +33,9 @@ bool BackgroundPlaCameraAction::isMetPreCondition()
     return true;
   }
 
-  // 初回で判定失敗した場合は動作しない
+  // 風景向き判定を失敗した場合、初回にプラレール撮影を行い、以後は動作しない
   if(!robot.getBackgroundDirectionResult().wasDetected) {
-    cout << "初回で判定を失敗したため、風景の撮影動作は行わない。" << endl;
+    cout << "風景向き判定を失敗したため、撮影動作は行わない。" << endl;
     return false;
   }
 
@@ -152,17 +152,16 @@ void BackgroundPlaCameraAction::run()
 
   PlaCameraAction plaCameraAction(robot, threshold, minArea, roi);
 
-  cv::Mat frame;
-
-  // 判定用のフレームの獲得
-  for(int i = 0; i < 5; ++i) {
-    robot.getCameraCaptureInstance().getFrame(frame);
-    this_thread::sleep_for(chrono::milliseconds(33));
-  }
-
   // もし初回で正面であればPlaCameraActionを実行、他の方向なら２回目でPlaCameraActionを実行、判定できなければ4回PlaCameraActionを実行
   if(position == 0) {
     // 向きの判定とresultの更新(detection)は1回目(初期位置で)の撮影でしか行わない
+    // 判定用のフレームの獲得
+    cv::Mat frame;
+    for(int i = 0; i < 5; ++i) {
+      robot.getCameraCaptureInstance().getFrame(frame);
+      this_thread::sleep_for(chrono::milliseconds(33));
+    }
+    cout << "風景向き判定を開始" << endl;
     detectDirection(frame);
 
     // もし判定結果が正面であればアップロード用のプラレール画像を取得する
@@ -176,8 +175,7 @@ void BackgroundPlaCameraAction::run()
         ImageUploader::uploadImage(filePath, fileName, 3);
       }).detach();
     } else if(!robot.getBackgroundDirectionResult().wasDetected) {
-      // 判定失敗時用のエンドポイントに１枚目をアップロード
-      cout << "風景向き判定用写真の撮影" << endl;
+      // 判定失敗時もプラレール撮影を行う
       string positionImageName = "bestframe_" + to_string(position);
       plaCameraAction.setImageSaveName(positionImageName);
       plaCameraAction.run();

--- a/modules/motions/BackgroundPlaCameraAction.cpp
+++ b/modules/motions/BackgroundPlaCameraAction.cpp
@@ -13,7 +13,8 @@ BackgroundPlaCameraAction::BackgroundPlaCameraAction(Robot& _robot, bool _isCloc
                                                      int _preTargetAngle, int _postTargetAngle,
                                                      int _basePower, double _threshold,
                                                      double _minArea, const cv::Rect _roi,
-                                                     int _position, double _kp, double _ki, double _kd)
+                                                     int _position, double _kp, double _ki,
+                                                     double _kd)
   : CompositeMotion(_robot),
     isClockwise(_isClockwise),
     preTargetAngle(_preTargetAngle),

--- a/modules/motions/BackgroundPlaCameraAction.cpp
+++ b/modules/motions/BackgroundPlaCameraAction.cpp
@@ -37,7 +37,7 @@ bool BackgroundPlaCameraAction::isMetPreCondition()
     return true;
   }
 
-  // 風景向き判定を失敗した場合、初回にプラレール撮影を行い、以後は動作しない
+  // 風景向き判定を失敗した場合、初回でプラレール撮影を行っているため、2回目以降は撮影動作を行わない
   if(!robot.getBackgroundDirectionResult().wasDetected) {
     cout << "風景向き判定を失敗したため、撮影動作は行わない。" << endl;
     return false;
@@ -156,7 +156,9 @@ void BackgroundPlaCameraAction::run()
 
   PlaCameraAction plaCameraAction(robot, threshold, minArea, roi);
 
-  // もし初回で正面であればPlaCameraActionを実行、他の方向なら２回目でPlaCameraActionを実行、判定できなければ4回PlaCameraActionを実行
+  // もし初回で正面であれば1回目のみPlaCameraActionを実行。他の方向なら２回目のみPlaCameraActionを実行。
+  // 判定できなければ4回PlaCameraActionを実行すべきだが、本番の大会では時間の都合上、
+  // 初回正面判定と同様、1回目のみPlaCameraActionを実行。
   if(position == 0) {
     // 向きの判定とresultの更新(detection)は1回目(初期位置で)の撮影でしか行わない
     // 判定用のフレームの獲得

--- a/modules/motions/BackgroundPlaCameraAction.cpp
+++ b/modules/motions/BackgroundPlaCameraAction.cpp
@@ -13,7 +13,7 @@ BackgroundPlaCameraAction::BackgroundPlaCameraAction(Robot& _robot, bool _isCloc
                                                      int _preTargetAngle, int _postTargetAngle,
                                                      int _basePower, double _threshold,
                                                      double _minArea, const cv::Rect _roi,
-                                                     int _position)
+                                                     int _position, double _kp, double _ki, double _kd)
   : CompositeMotion(_robot),
     isClockwise(_isClockwise),
     preTargetAngle(_preTargetAngle),
@@ -22,7 +22,10 @@ BackgroundPlaCameraAction::BackgroundPlaCameraAction(Robot& _robot, bool _isCloc
     threshold(_threshold),
     minArea(_minArea),
     roi(_roi),
-    position(_position)
+    position(_position),
+    kp(_kp),
+    ki(_ki),
+    kd(_kd)
 {
 }
 
@@ -143,7 +146,7 @@ void BackgroundPlaCameraAction::run()
   if(!isMetPreCondition()) return;
 
   // 撮影のため回頭
-  PidGain prePidGain = { 0.036, 0.02, 0.03 };
+  PidGain prePidGain = { kp, ki, kd };
   IMUAngleRotation preRotation(robot, preTargetAngle, basePower, isClockwise, prePidGain);
   preRotation.run();
 
@@ -199,7 +202,7 @@ void BackgroundPlaCameraAction::run()
   this_thread::sleep_for(chrono::milliseconds(10));
 
   // 黒線復帰のための回頭をする
-  PidGain postPidGain = { 0.036, 0.02, 0.03 };
+  PidGain postPidGain = { kp, ki, kd };
   IMUAngleRotation postRotation(robot, postTargetAngle, basePower, !isClockwise, postPidGain);
   postRotation.run();
 }

--- a/modules/motions/BackgroundPlaCameraAction.h
+++ b/modules/motions/BackgroundPlaCameraAction.h
@@ -8,7 +8,7 @@
 #define BACKGROUND_PLACAMERA_ACTION_H
 
 #include "PlaCameraAction.h"
-#include "AngleRotation.h"
+#include "IMUAngleRotation.h"
 #include "Robot.h"
 #include "FrameSave.h"
 #include "ImageUploader.h"
@@ -25,14 +25,14 @@ class BackgroundPlaCameraAction : public CompositeMotion {
    * @param _isClockwise 時計回りかどうか
    * @param _preTargetAngle カメラを風景に向けるための回頭角度
    * @param _postTargetAngle 黒線復帰のための回頭角度
-   * @param _targetRotationSpeed 目標回頭速度
+   * @param _basePower 回頭基準パワー値
    * @param _threshold 風景検出のしきい値
    * @param _minArea 最小面積
    * @param _roi 動体検出用の注目領域
    * @param _position 撮影位置（0:正面, 1:右, 2:後ろ, 3:左）
    */
   BackgroundPlaCameraAction(Robot& _robot, bool _isClockwise, int _preTargetAngle,
-                            int _postTargetAngle, double _targetRotationSpeed, double _threshold,
+                            int _postTargetAngle, int _basePower, double _threshold,
                             double _minArea, const cv::Rect roi, int _position);
 
   /**
@@ -41,14 +41,14 @@ class BackgroundPlaCameraAction : public CompositeMotion {
   void run() override;
 
  private:
-  bool isClockwise = false;            // 回頭方向
-  int preTargetAngle = 90;             // カメラを風景に向けるための回頭角度
-  int postTargetAngle = 90;            // 黒線復帰のための回頭角度
-  double targetRotationSpeed = 200.0;  // 目標回頭速度
-  double threshold = 30.0;             // 風景検出のしきい値
-  double minArea = 400.0;              // 最小面積
-  int position = 0;                    // 撮影位置（0:正面, 1:右, 2:後ろ, 3:左）
-  cv::Rect roi;                        // 動体検出用の注目領域
+  bool isClockwise = false;  // 回頭方向
+  int preTargetAngle = 90;   // カメラを風景に向けるための回頭角度
+  int postTargetAngle = 90;  // 黒線復帰のための回頭角度
+  int basePower = 50;        // 回頭基準パワー値
+  double threshold = 30.0;   // 風景検出のしきい値
+  double minArea = 400.0;    // 最小面積
+  int position = 0;          // 撮影位置（0:正面, 1:右, 2:後ろ, 3:左）
+  cv::Rect roi;              // 動体検出用の注目領域
   const std::string detectionTargetPath
       = "etrobocon2025/datafiles/detection_target";  // 判定用画像ディレクトリのパス
   const std::string detectionTargetName = "background";  // 風景向き判定用画像ファイル名

--- a/modules/motions/BackgroundPlaCameraAction.h
+++ b/modules/motions/BackgroundPlaCameraAction.h
@@ -36,8 +36,8 @@ class BackgroundPlaCameraAction : public CompositeMotion {
    */
   BackgroundPlaCameraAction(Robot& _robot, bool _isClockwise, int _preTargetAngle,
                             int _postTargetAngle, int _basePower, double _threshold,
-                            double _minArea, const cv::Rect roi, int _position,
-                            double _kp = 0.036, double _ki = 0.02, double _kd = 0.03);
+                            double _minArea, const cv::Rect roi, int _position, double _kp = 0.036,
+                            double _ki = 0.02, double _kd = 0.03);
 
   /**
    * @brief 撮影動作を実行する

--- a/modules/motions/BackgroundPlaCameraAction.h
+++ b/modules/motions/BackgroundPlaCameraAction.h
@@ -30,10 +30,14 @@ class BackgroundPlaCameraAction : public CompositeMotion {
    * @param _minArea 最小面積
    * @param _roi 動体検出用の注目領域
    * @param _position 撮影位置（0:正面, 1:右, 2:後ろ, 3:左）
+   * @param _kp 回頭PIDのP値
+   * @param _ki 回頭PIDのI値
+   * @param _kd 回頭PIDのD値
    */
   BackgroundPlaCameraAction(Robot& _robot, bool _isClockwise, int _preTargetAngle,
                             int _postTargetAngle, int _basePower, double _threshold,
-                            double _minArea, const cv::Rect roi, int _position);
+                            double _minArea, const cv::Rect roi, int _position,
+                            double _kp = 0.036, double _ki = 0.02, double _kd = 0.03);
 
   /**
    * @brief 撮影動作を実行する
@@ -49,6 +53,9 @@ class BackgroundPlaCameraAction : public CompositeMotion {
   double minArea = 400.0;    // 最小面積
   int position = 0;          // 撮影位置（0:正面, 1:右, 2:後ろ, 3:左）
   cv::Rect roi;              // 動体検出用の注目領域
+  double kp = 0.036;         // 回頭PIDのP値
+  double ki = 0.02;          // 回頭PIDのI値
+  double kd = 0.03;          // 回頭PIDのD値
   const std::string detectionTargetPath
       = "etrobocon2025/datafiles/detection_target";  // 判定用画像ディレクトリのパス
   const std::string detectionTargetName = "background";  // 風景向き判定用画像ファイル名

--- a/modules/motions/MiniFigCameraAction.cpp
+++ b/modules/motions/MiniFigCameraAction.cpp
@@ -12,7 +12,8 @@ using json = nlohmann::json;
 MiniFigCameraAction::MiniFigCameraAction(Robot& _robot, bool _isClockwise, int _preTargetAngle,
                                          int _postTargetAngle, int _basePower,
                                          double _backTargetDistance, double _forwardTargetDistance,
-                                         double _backSpeed, double _forwardSpeed, int _position)
+                                         double _backSpeed, double _forwardSpeed, int _position,
+                                         double _kp, double _ki, double _kd)
   : CompositeMotion(_robot),
     isClockwise(_isClockwise),
     preTargetAngle(_preTargetAngle),
@@ -22,7 +23,10 @@ MiniFigCameraAction::MiniFigCameraAction(Robot& _robot, bool _isClockwise, int _
     forwardTargetDistance(_forwardTargetDistance),
     backSpeed(_backSpeed),
     forwardSpeed(_forwardSpeed),
-    position(_position)
+    position(_position),
+    kp(_kp),
+    ki(_ki),
+    kd(_kd)
 {
 }
 
@@ -129,7 +133,7 @@ void MiniFigCameraAction::run()
   }
 
   // 撮影のための回頭をする
-  PidGain pidGain = { 0.036, 0.02, 0.03 };
+  PidGain pidGain = { kp, ki, kd };
   IMUAngleRotation preAR(robot, preTargetAngle, basePower, isClockwise, pidGain);
   preAR.run();
 
@@ -209,7 +213,7 @@ void MiniFigCameraAction::run()
   this_thread::sleep_for(chrono::milliseconds(10));
 
   // 黒線復帰のための回頭をする
-  PidGain postPidGain = { 0.036, 0.02, 0.03 };
+  PidGain postPidGain = { kp, ki, kd };
   IMUAngleRotation postAR(robot, postTargetAngle, basePower, !isClockwise, postPidGain);
   postAR.run();
 }

--- a/modules/motions/MiniFigCameraAction.cpp
+++ b/modules/motions/MiniFigCameraAction.cpp
@@ -151,6 +151,8 @@ void MiniFigCameraAction::run()
   cv::Mat frame;
   for(int i = 0; i < 5; i++) {
     robot.getCameraCaptureInstance().getFrame(frame);
+    // 動作安定のためのスリープ
+    this_thread::sleep_for(chrono::milliseconds(33));
   }
 
   if(position == 0) {

--- a/modules/motions/MiniFigCameraAction.h
+++ b/modules/motions/MiniFigCameraAction.h
@@ -9,7 +9,7 @@
 
 #include "SystemInfo.h"
 #include "CompositeMotion.h"
-#include "AngleRotation.h"
+#include "IMUAngleRotation.h"
 #include "DistanceStraight.h"
 #include "FrameSave.h"
 #include "ImageUploader.h"
@@ -24,7 +24,7 @@ class MiniFigCameraAction : public CompositeMotion {
    * カメラをミニフィグに向けるための回頭方向　true:時計回り, false:反時計回り
    * @param _preTargetAngle カメラをミニフィグに向けるための回頭角度
    * @param _postTargetAngle 黒線復帰のための回頭角度
-   * @param _targetRotationSpeed 撮影前後の回頭のための目標速度
+   * @param _basePower 撮影前後の回頭のための基準パワー値
    * @param _backTargetDistance 撮影前の後退距離
    * @param _forwardTargetDistance 撮影後の前進距離
    * @param _backSpeed 撮影前の後退速度の絶対値
@@ -32,9 +32,8 @@ class MiniFigCameraAction : public CompositeMotion {
    * @param _position 撮影位置（0が1回目の撮影箇所）反時計回りに3まで
    */
   MiniFigCameraAction(Robot& _robot, bool _isClockwise, int _preTargetAngle, int _postTargetAngle,
-                      double _targetRotationSpeed, double _backTargetDistance,
-                      double _forwardTargetDistance, double _backSpeed, double _forwardSpeed,
-                      int _position);
+                      int _basePower, double _backTargetDistance, double _forwardTargetDistance,
+                      double _backSpeed, double _forwardSpeed, int _position);
 
   /**
    * @brief ミニフィグの向きを判定し、必要なら撮影動作をスキップする準備処理
@@ -42,11 +41,11 @@ class MiniFigCameraAction : public CompositeMotion {
   void run() override;
 
  private:
-  bool isClockwise = false;          // カメラをミニフィグに向けるための回頭方向
-  int preTargetAngle = 90;           // カメラをミニフィグに向けるための回頭角度
-  int postTargetAngle = 90;          // 黒線復帰のための目標角度
-  double targetRotationSpeed = 200;  // 撮影前後の回頭のための目標速度
-  double backTargetDistance = 150;   // 撮影前の後退距離
+  bool isClockwise = false;         // カメラをミニフィグに向けるための回頭方向
+  int preTargetAngle = 90;          // カメラをミニフィグに向けるための回頭角度
+  int postTargetAngle = 90;         // 黒線復帰のための目標角度
+  int basePower = 50;               // 撮影前後の回頭のための基準パワー値
+  double backTargetDistance = 150;  // 撮影前の後退距離
   double forwardTargetDistance = 150;  // 撮影後の前進距離
   double backSpeed = 200;              // 撮影後の後退速度
   double forwardSpeed = 200;           // 撮影前の前進速度

--- a/modules/motions/MiniFigCameraAction.h
+++ b/modules/motions/MiniFigCameraAction.h
@@ -30,10 +30,14 @@ class MiniFigCameraAction : public CompositeMotion {
    * @param _backSpeed 撮影前の後退速度の絶対値
    * @param _forwardSpeed 撮影後の前進速度の絶対値
    * @param _position 撮影位置（0が1回目の撮影箇所）反時計回りに3まで
+   * @param _kp 回頭PIDのP値
+   * @param _ki 回頭PIDのI値
+   * @param _kd 回頭PIDのD値
    */
   MiniFigCameraAction(Robot& _robot, bool _isClockwise, int _preTargetAngle, int _postTargetAngle,
                       int _basePower, double _backTargetDistance, double _forwardTargetDistance,
-                      double _backSpeed, double _forwardSpeed, int _position);
+                      double _backSpeed, double _forwardSpeed, int _position,
+                      double _kp = 0.036, double _ki = 0.02, double _kd = 0.03);
 
   /**
    * @brief ミニフィグの向きを判定し、必要なら撮影動作をスキップする準備処理
@@ -50,6 +54,9 @@ class MiniFigCameraAction : public CompositeMotion {
   double backSpeed = 200;              // 撮影後の後退速度
   double forwardSpeed = 200;           // 撮影前の前進速度
   int position = 0;  // 撮影位置（0が1回目の撮影箇所）反時計回りに3まで
+  double kp = 0.036;  // 回頭PIDのP値
+  double ki = 0.02;   // 回頭PIDのI値
+  double kd = 0.03;   // 回頭PIDのD値
   const std::string detectionTargetPath
       = "etrobocon2025/datafiles/detection_target";  // 判定用画像ディレクトリのパス
   const std::string detectionTargetName = "fig";  // ミニフィグ向き判定用画像ファイル名

--- a/modules/motions/MiniFigCameraAction.h
+++ b/modules/motions/MiniFigCameraAction.h
@@ -36,8 +36,8 @@ class MiniFigCameraAction : public CompositeMotion {
    */
   MiniFigCameraAction(Robot& _robot, bool _isClockwise, int _preTargetAngle, int _postTargetAngle,
                       int _basePower, double _backTargetDistance, double _forwardTargetDistance,
-                      double _backSpeed, double _forwardSpeed, int _position,
-                      double _kp = 0.036, double _ki = 0.02, double _kd = 0.03);
+                      double _backSpeed, double _forwardSpeed, int _position, double _kp = 0.036,
+                      double _ki = 0.02, double _kd = 0.03);
 
   /**
    * @brief ミニフィグの向きを判定し、必要なら撮影動作をスキップする準備処理
@@ -53,7 +53,7 @@ class MiniFigCameraAction : public CompositeMotion {
   double forwardTargetDistance = 150;  // 撮影後の前進距離
   double backSpeed = 200;              // 撮影後の後退速度
   double forwardSpeed = 200;           // 撮影前の前進速度
-  int position = 0;  // 撮影位置（0が1回目の撮影箇所）反時計回りに3まで
+  int position = 0;   // 撮影位置（0が1回目の撮影箇所）反時計回りに3まで
   double kp = 0.036;  // 回頭PIDのP値
   double ki = 0.02;   // 回頭PIDのI値
   double kd = 0.03;   // 回頭PIDのD値

--- a/modules/utils/FrameSave.cpp
+++ b/modules/utils/FrameSave.cpp
@@ -18,7 +18,7 @@ void FrameSave::save(cv::Mat& frame, const std::string& filePath, const std::str
     }
   }
 
-  std::string imagePath = filePath + "/" + fileName + imgExtension;
+  std::string imagePath = filePath + "/" + fileName + JPEG_EXTENSION;
   if(!cv::imwrite(imagePath, frame)) {
     std::cerr << "画像の保存に失敗しました: " << imagePath << std::endl;
   }

--- a/modules/utils/FrameSave.h
+++ b/modules/utils/FrameSave.h
@@ -9,6 +9,7 @@
 
 #include "Robot.h"
 #include "CameraCapture.h"
+#include "SystemInfo.h"
 #include <opencv2/opencv.hpp>
 #include <filesystem>  // std::filesystemを使用するために追加
 #include <string>
@@ -24,8 +25,7 @@ class FrameSave {
   static void save(cv::Mat& frame, const std::string& filePath, const std::string& fileName);
 
  private:
-  inline static std::string imgExtension = ".JPEG";  // 保存するときの拡張子
-  FrameSave();                                       // インスタンス化の禁止
+  FrameSave();  // インスタンス化の禁止
 };
 
 #endif  // FRAME_SAVE_H

--- a/modules/utils/ImageUploader.cpp
+++ b/modules/utils/ImageUploader.cpp
@@ -62,3 +62,58 @@ bool ImageUploader::uploadImage(const std::string& filePath, const std::string& 
   std::cerr << "アップロードが" << maxAttempts << "回の試行後に失敗しました" << std::endl;
   return false;
 }
+
+bool ImageUploader::uploadMiniFigImage(const std::string& filePath,
+                                       const std::string& uploadFileName, int maxAttempts)
+{
+  // 空のファイルパスのチェック
+  if(filePath.empty()) {
+    std::cerr << "エラー: ファイルパスが空です" << std::endl;
+    return false;
+  }
+
+  // 空のファイル名のチェック
+  if(uploadFileName.empty()) {
+    std::cerr << "エラー: アップロード用ファイル名が空です" << std::endl;
+    return false;
+  }
+
+  // 拡張子がない場合は.JPEGを追加
+  std::string processedFileName = uploadFileName;
+  if(!uploadFileName.empty() && std::filesystem::path(uploadFileName).extension().empty()) {
+    processedFileName += ".JPEG";
+  }
+
+  // フルパスを作成
+  std::string fullImagePath = filePath + "/" + processedFileName;
+
+  // ファイル存在チェック
+  std::ifstream file(fullImagePath);
+  if(!file.good()) {
+    std::cerr << "エラー: ファイルが存在しません: " << fullImagePath << std::endl;
+    return false;
+  }
+
+  // パスを絶対パスに変換
+  std::string absolutePath = std::filesystem::absolute(fullImagePath).string();
+
+  // 無効な最大試行回数のチェック
+  if(maxAttempts <= 0) {
+    std::cerr << "エラー: 無効な再試行回数: " << maxAttempts << std::endl;
+    return false;
+  }
+
+  // 試行回数(attempts)が最大試行回数(maxAttempts)を超えるまで送信を試みる
+  int attempts = 0;
+  while(attempts < maxAttempts) {
+    std::string command = "make -C etrobocon2025 upload-minifig-image FILE_PATH=" + absolutePath;
+    int result = CommandExecutor::exec(command);
+    if(result == 0) {
+      return true;
+    }
+    attempts++;
+  }
+
+  std::cerr << "ミニフィグ画像のアップロードが" << maxAttempts << "回の試行後に失敗しました" << std::endl;
+  return false;
+}

--- a/modules/utils/ImageUploader.cpp
+++ b/modules/utils/ImageUploader.cpp
@@ -114,6 +114,7 @@ bool ImageUploader::uploadMiniFigImage(const std::string& filePath,
     attempts++;
   }
 
-  std::cerr << "ミニフィグ画像のアップロードが" << maxAttempts << "回の試行後に失敗しました" << std::endl;
+  std::cerr << "ミニフィグ画像のアップロードが" << maxAttempts << "回の試行後に失敗しました"
+            << std::endl;
   return false;
 }

--- a/modules/utils/ImageUploader.cpp
+++ b/modules/utils/ImageUploader.cpp
@@ -23,10 +23,10 @@ bool ImageUploader::uploadImage(const std::string& filePath, const std::string& 
     return false;
   }
 
-  // 拡張子がない場合は.JPEGを追加
+  // 拡張子がない場合は拡張子を追加
   std::string processedFileName = uploadFileName;
   if(!uploadFileName.empty() && std::filesystem::path(uploadFileName).extension().empty()) {
-    processedFileName += ".JPEG";
+    processedFileName += JPEG_EXTENSION;
   }
 
   // フルパスを作成
@@ -78,10 +78,10 @@ bool ImageUploader::uploadMiniFigImage(const std::string& filePath,
     return false;
   }
 
-  // 拡張子がない場合は.JPEGを追加
+  // 拡張子がない場合は拡張子を追加
   std::string processedFileName = uploadFileName;
   if(!uploadFileName.empty() && std::filesystem::path(uploadFileName).extension().empty()) {
-    processedFileName += ".JPEG";
+    processedFileName += JPEG_EXTENSION;
   }
 
   // フルパスを作成

--- a/modules/utils/ImageUploader.h
+++ b/modules/utils/ImageUploader.h
@@ -26,6 +26,16 @@ class ImageUploader {
   bool static uploadImage(const std::string& filePath, const std::string& uploadFileName,
                           int maxAttempts = 3);
 
+  /**
+   * @brief ミニフィグ画像をサーバーの/minifig/detectエンドポイントにアップロードする
+   * @param  filePath　送信する画像のファイルパス
+   * @param  uploadFileName　アップロード時のファイル名
+   * @param　maxAttempts　送信試行回数の上限
+   * @return アップロード成功時true、失敗時false
+   */
+  bool static uploadMiniFigImage(const std::string& filePath, const std::string& uploadFileName,
+                                 int maxAttempts = 3);
+
  private:
   ImageUploader();
 };

--- a/modules/utils/ImageUploader.h
+++ b/modules/utils/ImageUploader.h
@@ -8,6 +8,7 @@
 #define IMAGE_UPLOADER_H_
 
 #include "CommandExecutor.h"
+#include "SystemInfo.h"
 #include <string>
 #include <cstdlib>
 #include <iostream>

--- a/tests/BackgroundPlaCameraActionTest.cpp
+++ b/tests/BackgroundPlaCameraActionTest.cpp
@@ -20,19 +20,31 @@ namespace etrobocon2025_test {
     dummyPlaCameraCapture.setMotionLikeFrames();
 
     Robot robot(dummyPlaCameraCapture);
+    robot.getMotorControllerInstance().resetWheelsMotorPower();
+
+    // オフセット計算前に静止状態に設定
+    IMUTestControl::rotationStateRef() = 0;
+
+    // オフセット計算と補正行列計算を事前実行
+    robot.getIMUControllerInstance().initializeOffset();
+    robot.getIMUControllerInstance().calculateCorrectionMatrix();
+
+    // 回頭動作用に左回頭状態に設定
+    IMUTestControl::rotationStateRef() = -1;
+
     robot.getBackgroundDirectionResult().wasDetected = true;
     robot.getBackgroundDirectionResult().direction = BackgroundDirection::BACK;
     bool isClockwise = false;
-    int preTargetAngle = 90;
-    int postTargetAngle = 90;
-    double targetRotationSpeed = 200.0;
+    int preTargetAngle = 10;
+    int postTargetAngle = 1;
+    int basePower = 50;
     int position = 1;
     cv::Rect roi(0, 0, 800, 600);  // ROI領域を設定
 
     PlaCameraAction plaCameraAction(robot, 30.0, 1000.0, roi);
 
     BackgroundPlaCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle,
-                                     targetRotationSpeed, 30.0, 500.0, roi, position);
+                                     basePower, 30.0, 500.0, roi, position);
     testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     action.run();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
@@ -48,17 +60,29 @@ namespace etrobocon2025_test {
     dummyPlaCameraCapture.setMotionLikeFrames();
 
     Robot robot(dummyPlaCameraCapture);
+    robot.getMotorControllerInstance().resetWheelsMotorPower();
+
+    // オフセット計算前に静止状態に設定
+    IMUTestControl::rotationStateRef() = 0;
+
+    // オフセット計算と補正行列計算を事前実行
+    robot.getIMUControllerInstance().initializeOffset();
+    robot.getIMUControllerInstance().calculateCorrectionMatrix();
+
+    // 回頭動作用に左回頭状態に設定
+    IMUTestControl::rotationStateRef() = -1;
+
     robot.getBackgroundDirectionResult().wasDetected = true;
     robot.getBackgroundDirectionResult().direction = BackgroundDirection::BACK;
     bool isClockwise = false;
-    int preTargetAngle = 90;
-    int postTargetAngle = 90;
-    double targetRotationSpeed = 200.0;
+    int preTargetAngle = 10;
+    int postTargetAngle = 1;
+    int basePower = 50;
     int position = 2;
     cv::Rect roi(0, 0, 800, 600);  // ROI領域を設定
 
     BackgroundPlaCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle,
-                                     targetRotationSpeed, 30.0, 500.0, roi, position);
+                                     basePower, 30.0, 500.0, roi, position);
     testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     action.run();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了

--- a/tests/BackgroundPlaCameraActionTest.cpp
+++ b/tests/BackgroundPlaCameraActionTest.cpp
@@ -43,8 +43,8 @@ namespace etrobocon2025_test {
 
     PlaCameraAction plaCameraAction(robot, 30.0, 1000.0, roi);
 
-    BackgroundPlaCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle,
-                                     basePower, 30.0, 500.0, roi, position);
+    BackgroundPlaCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle, basePower,
+                                     30.0, 500.0, roi, position);
     testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     action.run();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
@@ -81,8 +81,8 @@ namespace etrobocon2025_test {
     int position = 2;
     cv::Rect roi(0, 0, 800, 600);  // ROI領域を設定
 
-    BackgroundPlaCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle,
-                                     basePower, 30.0, 500.0, roi, position);
+    BackgroundPlaCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle, basePower,
+                                     30.0, 500.0, roi, position);
     testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     action.run();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了

--- a/tests/MiniFigCameraActionTest.cpp
+++ b/tests/MiniFigCameraActionTest.cpp
@@ -17,21 +17,33 @@ namespace etrobocon2025_test {
   {
     DummyCameraCapture cameraCapture;
     Robot robot(cameraCapture);
+    robot.getMotorControllerInstance().resetWheelsMotorPower();
+
+    // オフセット計算前に静止状態に設定
+    IMUTestControl::rotationStateRef() = 0;
+
+    // オフセット計算と補正行列計算を事前実行
+    robot.getIMUControllerInstance().initializeOffset();
+    robot.getIMUControllerInstance().calculateCorrectionMatrix();
+
+    // 回頭動作用に左回頭状態に設定
+    IMUTestControl::rotationStateRef() = -1;
+
     robot.getMiniFigDirectionResult().wasDetected = true;
     robot.getMiniFigDirectionResult().direction = MiniFigDirection::BACK;
     bool isClockwise = false;
-    int preTargetAngle = 90;
-    int postTargetAngle = 90;
-    double targetRotationSpeed = 200;
+    int preTargetAngle = 10;
+    int postTargetAngle = 1;
+    int basePower = 50;
     double backTargetDistance = 150;
     double forwardTargetDistance = 150;
     double backSpeed = 200;
     double forwardSpeed = 200;
     int position = 1;
 
-    MiniFigCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle,
-                               targetRotationSpeed, backTargetDistance, forwardTargetDistance,
-                               backSpeed, forwardSpeed, position);
+    MiniFigCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle, basePower,
+                               backTargetDistance, forwardTargetDistance, backSpeed, forwardSpeed,
+                               position);
     testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     action.run();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
@@ -45,21 +57,33 @@ namespace etrobocon2025_test {
   {
     DummyCameraCapture cameraCapture;
     Robot robot(cameraCapture);
+    robot.getMotorControllerInstance().resetWheelsMotorPower();
+
+    // オフセット計算前に静止状態に設定
+    IMUTestControl::rotationStateRef() = 0;
+
+    // オフセット計算と補正行列計算を事前実行
+    robot.getIMUControllerInstance().initializeOffset();
+    robot.getIMUControllerInstance().calculateCorrectionMatrix();
+
+    // 回頭動作用に左回頭状態に設定
+    IMUTestControl::rotationStateRef() = -1;
+
     robot.getMiniFigDirectionResult().wasDetected = true;
     robot.getMiniFigDirectionResult().direction = MiniFigDirection::BACK;
     bool isClockwise = false;
-    int preTargetAngle = 90;
-    int postTargetAngle = 90;
-    double targetRotationSpeed = 200;
+    int preTargetAngle = 10;
+    int postTargetAngle = 1;
+    int basePower = 50;
     double backTargetDistance = 150;
     double forwardTargetDistance = 150;
     double backSpeed = 200;
     double forwardSpeed = 200;
     int position = 2;
 
-    MiniFigCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle,
-                               targetRotationSpeed, backTargetDistance, forwardTargetDistance,
-                               backSpeed, forwardSpeed, position);
+    MiniFigCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle, basePower,
+                               backTargetDistance, forwardTargetDistance, backSpeed, forwardSpeed,
+                               position);
     testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     action.run();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了
@@ -73,20 +97,33 @@ namespace etrobocon2025_test {
   {
     DummyCameraCapture cameraCapture;
     Robot robot(cameraCapture);
+    robot.getMotorControllerInstance().resetWheelsMotorPower();
+
+    // オフセット計算前に静止状態に設定
+    IMUTestControl::rotationStateRef() = 0;
+
+    // オフセット計算と補正行列計算を事前実行
+    robot.getIMUControllerInstance().initializeOffset();
+    robot.getIMUControllerInstance().calculateCorrectionMatrix();
+
+    // 回頭動作用に右回頭状態に設定
+    IMUTestControl::rotationStateRef() = 1;
+
     robot.getMiniFigDirectionResult().wasDetected = false;
     bool isClockwise = false;
-    int preTargetAngle = 90;
-    int postTargetAngle = 90;
-    double targetRotationSpeed = 200;
+    int preTargetAngle = 1;
+    int postTargetAngle = 10;
+    int basePower = 50;
     double backTargetDistance = 150;
     double forwardTargetDistance = 150;
     double backSpeed = 200;
     double forwardSpeed = 200;
     int position = 3;
 
-    MiniFigCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle,
-                               targetRotationSpeed, backTargetDistance, forwardTargetDistance,
-                               backSpeed, forwardSpeed, position);
+    MiniFigCameraAction action(robot, isClockwise, preTargetAngle, postTargetAngle, basePower,
+                               backTargetDistance, forwardTargetDistance, backSpeed, forwardSpeed,
+                               position);
+
     testing::internal::CaptureStdout();  // 標準出力キャプチャ開始
     action.run();
     string output = testing::internal::GetCapturedStdout();  // キャプチャ終了


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
* MCA、BCAにIMUで回頭するように修正
* minifig初回判定失敗時の動作の変更
* プラレール撮影にタイムアウト処理の追加

# 動作テスト

## 実験方法

## 実験データ

|  修正前  |  修正後  |
| ---- | ---- |
|  -  |  -  |
|  -  |  -  |

## 実験結果

## 添付資料
