### PR TITLE
#KL25-138 ライントレース・ダブルループ調整（BCAに直進とアーム上げ下げ動作の追加）

### DIFF
--- a/modules/MotionParser.cpp
+++ b/modules/MotionParser.cpp
@@ -277,38 +277,45 @@ vector<Motion*> MotionParser::createMotions(Robot& robot, string& commandFilePat
         // [2]:int preTargetAngle
         // [3]:int postTargetAngle
         // [4]:int 回頭基準パワー値
-        // [5]:double threshold（動体検出用）
-        // [6]:double minArea（動体矩形とみなす最小面積）
-        // [7]:int ROIの左上X座標
-        // [8]:int ROIの左上Y座標
-        // [9]:int ROIの幅
-        // [10]:int ROIの高さ
-        // [11]:int position（0=初期位置）
-        // [12]:string 回頭方法(relative or absolute)
-        // [13]:double kp（回頭PIDのP値）[オプション]
-        // [14]:double ki（回頭PIDのI値）[オプション]
-        // [15]:double kd（回頭PIDのD値）[オプション]
+        // [5]:double preTargetDistance（撮影前の直進距離）
+        // [6]:double postTargetDistance（撮影後の後退距離）
+        // [7]:double preTargetSpeed（撮影前の直進速度）
+        // [8]:double postTargetSpeed（撮影後の後退速度）
+        // [9]:int armPower（アームを上げるpower値）
+        // [10]:double threshold（動体検出用）
+        // [11]:double minArea（動体矩形とみなす最小面積）
+        // [12]:int ROIの左上X座標
+        // [13]:int ROIの左上Y座標
+        // [14]:int ROIの幅
+        // [15]:int ROIの高さ
+        // [16]:int position（0=初期位置）
+        // [17]:string 回頭方法(relative or absolute)
+        // [18]:double kp（回頭PIDのP値）[オプション]
+        // [19]:double ki（回頭PIDのI値）[オプション]
+        // [20]:double kd（回頭PIDのD値）[オプション]
 
       case COMMAND::BCA: {
         cv::Rect roi;
 
         bool isClockwise = convertBool("BCA", params[1]);
-        roi = cv::Rect(stoi(params[7]), stoi(params[8]), stoi(params[9]), stoi(params[10]));
+        roi = cv::Rect(stoi(params[12]), stoi(params[13]), stoi(params[14]), stoi(params[15]));
 
         BackgroundPlaCameraAction* bca;
-        if(params.size() >= 16) {
+        if(params.size() >= 21) {
           // PID値が指定されている場合
-          bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]), stoi(params[3]),
-                                              stoi(params[4]), stod(params[5]), stod(params[6]),
-                                              roi, stoi(params[11]),
-                                              convertRotationModeToBool(params[12]),
-                                              stod(params[13]), stod(params[14]), stod(params[15]));
+          bca = new BackgroundPlaCameraAction(
+              robot, isClockwise, stoi(params[2]), stoi(params[3]), stoi(params[4]),
+              stod(params[5]), stod(params[6]), stod(params[7]), stod(params[8]), stoi(params[9]),
+              stod(params[10]), stod(params[11]), roi, stoi(params[16]),
+              convertRotationModeToBool(params[17]), stod(params[18]), stod(params[19]),
+              stod(params[20]));
         } else {
           // PID値が指定されていない場合、デフォルト値を使用
-          bca = new BackgroundPlaCameraAction(robot, isClockwise, stoi(params[2]), stoi(params[3]),
-                                              stoi(params[4]), stod(params[5]), stod(params[6]),
-                                              roi, stoi(params[11]),
-                                              convertRotationModeToBool(params[12]));
+          bca = new BackgroundPlaCameraAction(
+              robot, isClockwise, stoi(params[2]), stoi(params[3]), stoi(params[4]),
+              stod(params[5]), stod(params[6]), stod(params[7]), stod(params[8]), stoi(params[9]),
+              stod(params[10]), stod(params[11]), roi, stoi(params[16]),
+              convertRotationModeToBool(params[17]));
         }
 
         motionList.push_back(bca);

--- a/modules/motions/BackgroundPlaCameraAction.cpp
+++ b/modules/motions/BackgroundPlaCameraAction.cpp
@@ -83,6 +83,8 @@ void BackgroundPlaCameraAction::run()
   IMUDistanceStraight preStraight(robot, preTargetDistance, preTargetSpeed, prePidGain);
   preStraight.run();
 
+  robot.getMotorControllerInstance().stopWheelsMotor();
+
   // 綺麗な写真の撮影のためのスリープ
   this_thread::sleep_for(chrono::milliseconds(100));
 
@@ -112,8 +114,6 @@ void BackgroundPlaCameraAction::run()
 
   // 動作安定のためのスリープ
   this_thread::sleep_for(chrono::milliseconds(10));
-
-  robot.getMotorControllerInstance().stopWheelsMotor();
 
   PidGain postPidGain = { kp, ki, kd };
 

--- a/modules/motions/BackgroundPlaCameraAction.cpp
+++ b/modules/motions/BackgroundPlaCameraAction.cpp
@@ -11,17 +11,21 @@
 
 using namespace std;
 
-BackgroundPlaCameraAction::BackgroundPlaCameraAction(Robot& _robot, bool _isClockwise,
-                                                     int _preTargetAngle, int _postTargetAngle,
-                                                     int _basePower, double _threshold,
-                                                     double _minArea, const cv::Rect _roi,
-                                                     int _position, bool _isAbsoluteAngleMode,
-                                                     double _kp, double _ki, double _kd)
+BackgroundPlaCameraAction::BackgroundPlaCameraAction(
+    Robot& _robot, bool _isClockwise, int _preTargetAngle, int _postTargetAngle, int _basePower,
+    double _preTargetDistance, double _postTargetDistance, double _preTargetSpeed,
+    double _postTargetSpeed, int _armPower, double _threshold, double _minArea, const cv::Rect _roi,
+    int _position, bool _isAbsoluteAngleMode, double _kp, double _ki, double _kd)
   : CompositeMotion(_robot),
     isClockwise(_isClockwise),
     preTargetAngle(_preTargetAngle),
     postTargetAngle(_postTargetAngle),
     basePower(_basePower),
+    preTargetDistance(_preTargetDistance),
+    postTargetDistance(_postTargetDistance),
+    preTargetSpeed(_preTargetSpeed),
+    postTargetSpeed(_postTargetSpeed),
+    armPower(_armPower),
     threshold(_threshold),
     minArea(_minArea),
     roi(_roi),
@@ -60,11 +64,24 @@ void BackgroundPlaCameraAction::run()
 {
   if(!isMetPreCondition()) return;
 
-  // 撮影のため回頭
   PidGain prePidGain = { kp, ki, kd };
+  // 撮影のため回頭
   IMUAngleRotation preRotation(robot, preTargetAngle, basePower, isClockwise, prePidGain,
                                isAbsoluteAngleMode);
   preRotation.run();
+
+  // 動作安定のためのスリープ
+  this_thread::sleep_for(chrono::milliseconds(10));
+
+  // アームを上げる
+  robot.getMotorControllerInstance().setArmMotorPower(armPower);
+
+  // 動作安定のためのスリープ
+  this_thread::sleep_for(chrono::milliseconds(10));
+
+  // 撮影のため直進
+  IMUDistanceStraight preStraight(robot, preTargetDistance, preTargetSpeed, prePidGain);
+  preStraight.run();
 
   // 綺麗な写真の撮影のためのスリープ
   this_thread::sleep_for(chrono::milliseconds(100));
@@ -96,8 +113,26 @@ void BackgroundPlaCameraAction::run()
   // 動作安定のためのスリープ
   this_thread::sleep_for(chrono::milliseconds(10));
 
-  // 黒線復帰のための回頭をする
+  robot.getMotorControllerInstance().stopWheelsMotor();
+
   PidGain postPidGain = { kp, ki, kd };
+
+  // 黒線復帰のための後退をする
+  IMUDistanceStraight postStraight(robot, postTargetDistance, postTargetSpeed, postPidGain);
+  postStraight.run();
+
+  // 動作安定のためのスリープ
+  this_thread::sleep_for(chrono::milliseconds(10));
+
+  robot.getMotorControllerInstance().stopWheelsMotor();
+
+  // アームを下げる
+  robot.getMotorControllerInstance().setArmMotorPower(-armPower);
+
+  // 動作安定のためのスリープ
+  this_thread::sleep_for(chrono::milliseconds(10));
+
+  // 黒線復帰のための回頭をする
   IMUAngleRotation postRotation(robot, postTargetAngle, basePower, !isClockwise, postPidGain,
                                 isAbsoluteAngleMode);
   postRotation.run();

--- a/modules/motions/BackgroundPlaCameraAction.h
+++ b/modules/motions/BackgroundPlaCameraAction.h
@@ -2,6 +2,7 @@
 #define BACKGROUND_PLA_CAMERA_ACTION_H
 
 #include "IMUAngleRotation.h"
+#include "IMUDistanceStraight.h"
 #include "CompositeMotion.h"
 #include <opencv2/opencv.hpp>  // For cv::Rect
 
@@ -16,6 +17,11 @@ class BackgroundPlaCameraAction : public CompositeMotion {
    * @param _preTargetAngle カメラを風景に向けるための回頭角度
    * @param _postTargetAngle 黒線復帰のための回頭角度
    * @param _basePower 回頭基準パワー値
+   * @param _preTargetDistance 撮影前の直進距離 [mm]
+   * @param _postTargetDistance 撮影後の後退距離 [mm]
+   * @param _preTargetSpeed 目標直進速度 [mm/s]
+   * @param _postTargetSpeed 目標後退速度 [mm/s]
+   * @param _armPower アームを上げるpower値
    * @param _threshold 風景検出のしきい値
    * @param _minArea 最小面積
    * @param _roi 動体検出用の注目領域
@@ -26,20 +32,27 @@ class BackgroundPlaCameraAction : public CompositeMotion {
    * @param _kd 回頭PIDのD値
    */
   BackgroundPlaCameraAction(Robot& _robot, bool _isClockwise, int _preTargetAngle,
-                            int _postTargetAngle, int _basePower, double _threshold,
+                            int _postTargetAngle, int _basePower, double _preTargetDistance,
+                            double _postTargetDistance, double _preTargetSpeed,
+                            double _postTargetSpeed, int _armPower, double _threshold,
                             double _minArea, const cv::Rect roi, int _position,
                             bool _isAbsoluteAngleMode, double _kp = 0.036, double _ki = 0.02,
                             double _kd = 0.03);
 
  private:
-  bool isClockwise = false;          // 回頭方向
-  int preTargetAngle = 90;           // カメラを風景に向けるための回頭角度
-  int postTargetAngle = 90;          // 黒線復帰のための回頭角度
-  int basePower = 50;                // 回頭基準パワー値
-  double threshold = 30.0;           // 風景検出のしきい値
-  double minArea = 400.0;            // 最小面積
-  int position = 0;                  // 撮影位置（0:正面, 1:右, 2:後ろ, 3:左）
-  cv::Rect roi;                      // 動体検出用の注目領域
+  bool isClockwise = false;            // 回頭方向
+  int preTargetAngle = 90;             // カメラを風景に向けるための回頭角度
+  int postTargetAngle = 90;            // 黒線復帰のための回頭角度
+  int basePower = 50;                  // 回頭基準パワー値
+  double preTargetDistance = 100.0;    // 撮影前の直進距離
+  double postTargetDistance = -100.0;  // 撮影後の後退距離
+  double preTargetSpeed = 200.0;       // 直進目標速度
+  double postTargetSpeed = -200.0;     // 後退目標速度
+  int armPower = 50;                   // アームを上げるpower値
+  double threshold = 30.0;             // 風景検出のしきい値
+  double minArea = 400.0;              // 最小面積
+  int position = 0;                    // 撮影位置（0:正面, 1:右, 2:後ろ, 3:左）
+  cv::Rect roi;                        // 動体検出用の注目領域
   bool isAbsoluteAngleMode = false;  // 回頭方法 false:相対角度回頭, true:絶対角度回頭
   double kp = 0.036;                 // 回頭PIDのP値
   double ki = 0.02;                  // 回頭PIDのI値


### PR DESCRIPTION
# チェックリスト

- [x] clang-format している
- [x] コーディング規約に準じている
- [x] チケットの完了条件を満たしている

# 変更点
BCAに風景・プラを画角に入れるための直進とアームを上げる動作の追加